### PR TITLE
Add skeleton for WP Auction Manager plugin

### DIFF
--- a/admin/class-wcap-admin.php
+++ b/admin/class-wcap-admin.php
@@ -1,0 +1,20 @@
+<?php
+class WCAP_Admin {
+    public function __construct() {
+        add_action( 'admin_menu', [ $this, 'add_menu' ] );
+    }
+
+    public function add_menu() {
+        add_menu_page( 
+            __( 'WP Auction Manager', 'wcap' ),
+            __( 'Auctions', 'wcap' ),
+            'manage_options',
+            'wcap-admin',
+            [ $this, 'render_page' ]
+        );
+    }
+
+    public function render_page() {
+        echo '<div class="wrap"><h1>' . esc_html__( 'WP Auction Manager', 'wcap' ) . '</h1></div>';
+    }
+}

--- a/includes/api-integrations/class-api-provider.php
+++ b/includes/api-integrations/class-api-provider.php
@@ -1,0 +1,4 @@
+<?php
+interface WCAP_API_Provider {
+    public function send( $to, $message );
+}

--- a/includes/api-integrations/class-twilio-provider.php
+++ b/includes/api-integrations/class-twilio-provider.php
@@ -1,0 +1,6 @@
+<?php
+class WCAP_Twilio_Provider implements WCAP_API_Provider {
+    public function send( $to, $message ) {
+        // Placeholder for Twilio API call
+    }
+}

--- a/includes/class-wcap-auction.php
+++ b/includes/class-wcap-auction.php
@@ -1,0 +1,23 @@
+<?php
+if ( class_exists( 'WC_Product' ) && ! class_exists( 'WC_Product_Auction' ) ) {
+    class WC_Product_Auction extends WC_Product {
+        public function get_type() {
+            return 'auction';
+        }
+    }
+}
+
+class WCAP_Auction {
+    public function __construct() {
+        add_action( 'init', [ $this, 'register_product_type' ] );
+    }
+
+    public function register_product_type() {
+        add_filter( 'product_type_selector', [ $this, 'add_product_type' ] );
+    }
+
+    public function add_product_type( $types ) {
+        $types['auction'] = __( 'Auction', 'wcap' );
+        return $types;
+    }
+}

--- a/includes/class-wcap-bid.php
+++ b/includes/class-wcap-bid.php
@@ -1,0 +1,12 @@
+<?php
+class WCAP_Bid {
+    public function __construct() {
+        add_action( 'wp_ajax_wcap_place_bid', [ $this, 'place_bid' ] );
+        add_action( 'wp_ajax_nopriv_wcap_place_bid', [ $this, 'place_bid' ] );
+    }
+
+    public function place_bid() {
+        // Placeholder for AJAX bid handling
+        wp_send_json_success( [ 'message' => 'Bid received' ] );
+    }
+}

--- a/includes/class-wcap-loader.php
+++ b/includes/class-wcap-loader.php
@@ -1,0 +1,16 @@
+<?php
+class WCAP_Loader {
+    public function run() {
+        // Load dependencies
+        require_once WCAP_PLUGIN_DIR . 'includes/class-wcap-auction.php';
+        require_once WCAP_PLUGIN_DIR . 'includes/class-wcap-bid.php';
+        require_once WCAP_PLUGIN_DIR . 'admin/class-wcap-admin.php';
+        require_once WCAP_PLUGIN_DIR . 'public/class-wcap-public.php';
+
+        // Init classes
+        new WCAP_Auction();
+        new WCAP_Bid();
+        new WCAP_Admin();
+        new WCAP_Public();
+    }
+}

--- a/public/class-wcap-public.php
+++ b/public/class-wcap-public.php
@@ -1,0 +1,11 @@
+<?php
+class WCAP_Public {
+    public function __construct() {
+        add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
+    }
+
+    public function enqueue_scripts() {
+        wp_enqueue_script( 'wcap-ajax-bid', WCAP_PLUGIN_URL . 'public/js/ajax-bid.js', [ 'jquery' ], WCAP_PLUGIN_VERSION, true );
+        wp_localize_script( 'wcap-ajax-bid', 'wcap_ajax', [ 'ajax_url' => admin_url( 'admin-ajax.php' ) ] );
+    }
+}

--- a/public/js/ajax-bid.js
+++ b/public/js/ajax-bid.js
@@ -1,0 +1,8 @@
+jQuery(function($){
+    $('.wcap-bid-button').on('click', function(e){
+        e.preventDefault();
+        $.post(wcap_ajax.ajax_url, { action: 'wcap_place_bid' }, function(res){
+            alert(res.data.message);
+        });
+    });
+});

--- a/templates/auction-listing.php
+++ b/templates/auction-listing.php
@@ -1,0 +1,9 @@
+<?php
+get_header();
+?>
+<div class="auction-listing">
+    <h1><?php _e('Auctions', 'wcap'); ?></h1>
+    <?php // Placeholder for listing auctions ?>
+</div>
+<?php
+get_footer();

--- a/templates/single-auction.php
+++ b/templates/single-auction.php
@@ -1,0 +1,9 @@
+<?php
+get_header();
+?>
+<div class="auction-single">
+    <h1><?php the_title(); ?></h1>
+    <button class="wcap-bid-button">Place Bid</button>
+</div>
+<?php
+get_footer();

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,5 @@
+<?php
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+    exit();
+}
+// Cleanup code here e.g., drop custom tables

--- a/wp-auction-manager.php
+++ b/wp-auction-manager.php
@@ -1,0 +1,29 @@
+<?php
+/*
+Plugin Name: WP Auction Manager
+Description: Convert WooCommerce products into auctions with optional real-time and notification integrations.
+Version: 0.1.0
+Author: Codex GPT
+*/
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+define( 'WCAP_PLUGIN_VERSION', '0.1.0' );
+define( 'WCAP_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+
+define( 'WCAP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
+define( 'WCAP_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
+
+require_once WCAP_PLUGIN_DIR . 'includes/class-wcap-loader.php';
+
+function wcap_run_plugin() {
+    $loader = new WCAP_Loader();
+    $loader->run();
+}
+
+wcap_run_plugin();
+
+?>


### PR DESCRIPTION
## Summary
- implement initial plugin skeleton per PROMPT
- add loader, admin, public, auction and bid classes
- include API provider interface and sample Twilio implementation
- create basic JS for AJAX bidding
- add template placeholders and uninstall script

## Testing
- `php -l` on all PHP files

------
https://chatgpt.com/codex/tasks/task_e_6888a3cfe5108333af05b7fec706ac1b