### PR TITLE
Add AJAX nonce verification

### DIFF
--- a/includes/class-wpam-bid.php
+++ b/includes/class-wpam-bid.php
@@ -6,6 +6,8 @@ class WPAM_Bid {
     }
 
     public function place_bid() {
+        check_ajax_referer( 'wpam_place_bid', 'nonce' );
+
         if ( empty( $_POST['auction_id'] ) || empty( $_POST['bid'] ) ) {
             wp_send_json_error( [ 'message' => __( 'Invalid bid data', 'wpam' ) ] );
         }

--- a/includes/class-wpam-watchlist.php
+++ b/includes/class-wpam-watchlist.php
@@ -6,6 +6,8 @@ class WPAM_Watchlist {
     }
 
     public function toggle_watchlist() {
+        check_ajax_referer( 'wpam_toggle_watchlist', 'nonce' );
+
         if ( empty( $_POST['auction_id'] ) ) {
             wp_send_json_error( [ 'message' => __( 'Invalid auction', 'wpam' ) ] );
         }

--- a/public/class-wpam-public.php
+++ b/public/class-wpam-public.php
@@ -6,6 +6,14 @@ class WPAM_Public {
 
     public function enqueue_scripts() {
         wp_enqueue_script( 'wpam-ajax-bid', WPAM_PLUGIN_URL . 'public/js/ajax-bid.js', [ 'jquery' ], WPAM_PLUGIN_VERSION, true );
-        wp_localize_script( 'wpam-ajax-bid', 'wpam_ajax', [ 'ajax_url' => admin_url( 'admin-ajax.php' ) ] );
+        wp_localize_script(
+            'wpam-ajax-bid',
+            'wpam_ajax',
+            [
+                'ajax_url'        => admin_url( 'admin-ajax.php' ),
+                'bid_nonce'       => wp_create_nonce( 'wpam_place_bid' ),
+                'watchlist_nonce' => wp_create_nonce( 'wpam_toggle_watchlist' ),
+            ]
+        );
     }
 }

--- a/public/js/ajax-bid.js
+++ b/public/js/ajax-bid.js
@@ -8,7 +8,8 @@ jQuery(function($){
             {
                 action: 'wpam_place_bid',
                 auction_id: auctionId,
-                bid: bidInput.val()
+                bid: bidInput.val(),
+                nonce: wpam_ajax.bid_nonce
             },
             function(res){
                 alert(res.data.message);
@@ -23,7 +24,8 @@ jQuery(function($){
             wpam_ajax.ajax_url,
             {
                 action: 'wpam_toggle_watchlist',
-                auction_id: auctionId
+                auction_id: auctionId,
+                nonce: wpam_ajax.watchlist_nonce
             },
             function(res){
                 alert(res.data.message);

--- a/templates/single-auction.php
+++ b/templates/single-auction.php
@@ -5,10 +5,12 @@ get_header();
     <h1><?php the_title(); ?></h1>
     <form class="wpam-bid-form">
         <input type="number" step="0.01" class="wpam-bid-input" />
+        <?php wp_nonce_field( 'wpam_place_bid', 'wpam_bid_nonce', false ); ?>
         <button class="wpam-bid-button" data-auction-id="<?php the_ID(); ?>">
             <?php _e( 'Place Bid', 'wpam' ); ?>
         </button>
     </form>
+    <?php wp_nonce_field( 'wpam_toggle_watchlist', 'wpam_watchlist_nonce', false ); ?>
     <button class="wpam-watchlist-button" data-auction-id="<?php the_ID(); ?>">
         <?php _e( 'Toggle Watchlist', 'wpam' ); ?>
     </button>


### PR DESCRIPTION
## Summary
- send nonce values with AJAX actions
- generate bid and watchlist nonces for scripts
- embed nonce fields in single auction template
- verify AJAX nonce for bid and watchlist handlers

## Testing
- `php -l public/js/ajax-bid.js`
- `php -l templates/single-auction.php`
- `php -l public/class-wpam-public.php`
- `php -l includes/class-wpam-bid.php`
- `php -l includes/class-wpam-watchlist.php`

------
https://chatgpt.com/codex/tasks/task_e_6888b32932608333be4970e8df590571