### PR TITLE
Implement uninstall cleanup

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -2,4 +2,20 @@
 if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
     exit();
 }
-// Cleanup code here e.g., drop custom tables
+
+// Verify the current user has permission to uninstall plugins.
+if ( ! current_user_can( 'activate_plugins' ) ) {
+    return;
+}
+
+global $wpdb;
+
+// Drop custom tables created by the plugin.
+$tables = [
+    $wpdb->prefix . 'wc_auction_bids',
+    $wpdb->prefix . 'wc_auction_watchlists',
+];
+
+foreach ( $tables as $table ) {
+    $wpdb->query( "DROP TABLE IF EXISTS $table" );
+}

--- a/wp-auction-manager.php
+++ b/wp-auction-manager.php
@@ -5,6 +5,7 @@ Description: Convert WooCommerce products into auctions with optional real-time 
 Version: 1.0.0
 Author: Muzammil Hussain
 Author URI: https://muzammil.dev
+Uninstall: uninstall.php
 */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
## Summary
- remove tables when plugin uninstalled
- add Uninstall header to main plugin file

## Testing
- `php -l uninstall.php`
- `php -l wp-auction-manager.php`


------
https://chatgpt.com/codex/tasks/task_e_6888b32df29483338e5eb58d18c617dc