### PR TITLE
Add translation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# WP Auction Manager
+
+WP Auction Manager extends WooCommerce with auction functionality. Translation files live in the `languages` directory.
+
+## Updating the POT file
+
+Run the following command from the plugin root to regenerate the template file:
+
+```bash
+php wp-cli.phar i18n make-pot . languages/wp-auction-manager.pot --allow-root
+```
+
+## Creating translations
+
+1. Create a `.po` file from the POT template using `msginit` or any PO editor. For example:
+   ```bash
+   msginit --locale=fr_FR --input=languages/wp-auction-manager.pot \
+     --output-file=languages/wp-auction-manager-fr_FR.po
+   ```
+2. After translating, compile the `.po` file into a `.mo` file:
+   ```bash
+   msgfmt languages/wp-auction-manager-fr_FR.po \
+     -o languages/wp-auction-manager-fr_FR.mo
+   ```
+3. Place the resulting `.mo` file in the `languages` directory.

--- a/languages/wp-auction-manager.pot
+++ b/languages/wp-auction-manager.pot
@@ -1,0 +1,35 @@
+# Copyright (C) 2025 Muzammil Hussain
+# This file is distributed under the same license as the WP Auction Manager plugin.
+msgid ""
+msgstr ""
+"Project-Id-Version: WP Auction Manager 1.0.0\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wp-auction-manager\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-07-29T11:42:44+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: wp-auction-manager\n"
+
+#. Plugin Name of the plugin
+#: wp-auction-manager.php
+msgid "WP Auction Manager"
+msgstr ""
+
+#. Description of the plugin
+#: wp-auction-manager.php
+msgid "Convert WooCommerce products into auctions with optional real-time and notification integrations."
+msgstr ""
+
+#. Author of the plugin
+#: wp-auction-manager.php
+msgid "Muzammil Hussain"
+msgstr ""
+
+#. Author URI of the plugin
+#: wp-auction-manager.php
+msgid "https://muzammil.dev"
+msgstr ""

--- a/wp-auction-manager.php
+++ b/wp-auction-manager.php
@@ -21,6 +21,14 @@ require_once WPAM_PLUGIN_DIR . 'includes/class-wpam-loader.php';
 require_once WPAM_PLUGIN_DIR . 'includes/class-wpam-install.php';
 
 /**
+ * Load plugin translation files.
+ */
+function wpam_load_textdomain() {
+    load_plugin_textdomain( 'wpam', false, basename( dirname( __FILE__ ) ) . '/languages' );
+}
+add_action( 'init', 'wpam_load_textdomain' );
+
+/**
  * Show admin notice when WooCommerce is missing.
  */
 function wpam_wc_missing_notice() {


### PR DESCRIPTION
## Summary
- generate translation template under `languages`
- hook translations on `init`
- document creating and compiling `.mo` files

## Testing
- `php -l wp-auction-manager.php`
- `find . -name '*.php' -not -path './.git/*' | xargs -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_6888b3320f1c8333a051e70e60eaf119