### PR TITLE
Add admin tables for auctions and bids

### DIFF
--- a/admin/class-wpam-admin.php
+++ b/admin/class-wpam-admin.php
@@ -2,19 +2,134 @@
 class WPAM_Admin {
     public function __construct() {
         add_action( 'admin_menu', [ $this, 'add_menu' ] );
+        add_action( 'admin_init', [ $this, 'register_settings' ] );
     }
 
     public function add_menu() {
-        add_menu_page( 
+        add_menu_page(
             __( 'WP Auction Manager', 'wpam' ),
             __( 'Auctions', 'wpam' ),
             'manage_options',
-            'wpam-admin',
-            [ $this, 'render_page' ]
+            'wpam-auctions',
+            [ $this, 'render_auctions_page' ],
+            'dashicons-hammer'
+        );
+
+        add_submenu_page(
+            'wpam-auctions',
+            __( 'All Auctions', 'wpam' ),
+            __( 'All Auctions', 'wpam' ),
+            'manage_options',
+            'wpam-auctions',
+            [ $this, 'render_auctions_page' ]
+        );
+
+        add_submenu_page(
+            'wpam-auctions',
+            __( 'Bids', 'wpam' ),
+            __( 'Bids', 'wpam' ),
+            'manage_options',
+            'wpam-bids',
+            [ $this, 'render_bids_page' ]
+        );
+
+        add_submenu_page(
+            'wpam-auctions',
+            __( 'Integrations', 'wpam' ),
+            __( 'Settings', 'wpam' ),
+            'manage_options',
+            'wpam-settings',
+            [ $this, 'render_settings_page' ]
         );
     }
 
-    public function render_page() {
-        echo '<div class="wrap"><h1>' . esc_html__( 'WP Auction Manager', 'wpam' ) . '</h1></div>';
+    public function register_settings() {
+        register_setting( 'wpam_settings', 'wpam_twilio_sid' );
+        register_setting( 'wpam_settings', 'wpam_twilio_token' );
+        register_setting( 'wpam_settings', 'wpam_twilio_from' );
+
+        add_settings_section( 'wpam_twilio', __( 'Twilio Integration', 'wpam' ), '__return_false', 'wpam_settings' );
+
+        add_settings_field(
+            'wpam_twilio_sid',
+            __( 'Twilio SID', 'wpam' ),
+            [ $this, 'field_twilio_sid' ],
+            'wpam_settings',
+            'wpam_twilio'
+        );
+
+        add_settings_field(
+            'wpam_twilio_token',
+            __( 'Twilio Token', 'wpam' ),
+            [ $this, 'field_twilio_token' ],
+            'wpam_settings',
+            'wpam_twilio'
+        );
+
+        add_settings_field(
+            'wpam_twilio_from',
+            __( 'Twilio From Number', 'wpam' ),
+            [ $this, 'field_twilio_from' ],
+            'wpam_settings',
+            'wpam_twilio'
+        );
+    }
+
+    public function field_twilio_sid() {
+        $value = esc_attr( get_option( 'wpam_twilio_sid', '' ) );
+        echo '<input type="text" class="regular-text" name="wpam_twilio_sid" value="' . $value . '" />';
+    }
+
+    public function field_twilio_token() {
+        $value = esc_attr( get_option( 'wpam_twilio_token', '' ) );
+        echo '<input type="text" class="regular-text" name="wpam_twilio_token" value="' . $value . '" />';
+    }
+
+    public function field_twilio_from() {
+        $value = esc_attr( get_option( 'wpam_twilio_from', '' ) );
+        echo '<input type="text" class="regular-text" name="wpam_twilio_from" value="' . $value . '" />';
+    }
+
+    public function render_auctions_page() {
+        require_once WPAM_PLUGIN_DIR . 'admin/class-wpam-auctions-table.php';
+        $table = new WPAM_Auctions_Table();
+        $table->prepare_items();
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__( 'Auctions', 'wpam' ) . '</h1>';
+        echo '<form method="get">';
+        echo '<input type="hidden" name="page" value="wpam-auctions" />';
+        $table->views();
+        $table->display();
+        echo '</form></div>';
+    }
+
+    public function render_bids_page() {
+        require_once WPAM_PLUGIN_DIR . 'admin/class-wpam-bids-table.php';
+        $auction_id = isset( $_GET['auction_id'] ) ? absint( $_GET['auction_id'] ) : 0;
+        echo '<div class="wrap">';
+        if ( ! $auction_id ) {
+            echo '<h1>' . esc_html__( 'Bids', 'wpam' ) . '</h1>';
+            echo '<p>' . esc_html__( 'No auction selected.', 'wpam' ) . '</p>';
+            echo '</div>';
+            return;
+        }
+        $table = new WPAM_Bids_Table( $auction_id );
+        $table->prepare_items();
+        echo '<h1>' . sprintf( esc_html__( 'Bids for Auction #%d', 'wpam' ), $auction_id ) . '</h1>';
+        echo '<form method="get">';
+        echo '<input type="hidden" name="page" value="wpam-bids" />';
+        echo '<input type="hidden" name="auction_id" value="' . esc_attr( $auction_id ) . '" />';
+        $table->display();
+        echo '</form></div>';
+    }
+
+    public function render_settings_page() {
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__( 'Integrations', 'wpam' ) . '</h1>';
+        echo '<form method="post" action="options.php">';
+        settings_fields( 'wpam_settings' );
+        do_settings_sections( 'wpam_settings' );
+        submit_button();
+        echo '</form></div>';
     }
 }

--- a/admin/class-wpam-auctions-table.php
+++ b/admin/class-wpam-auctions-table.php
@@ -1,0 +1,129 @@
+<?php
+if ( ! class_exists( 'WP_List_Table' ) ) {
+    require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+}
+
+class WPAM_Auctions_Table extends WP_List_Table {
+    public function prepare_items() {
+        $status = isset( $_GET['status'] ) ? sanitize_text_field( wp_unslash( $_GET['status'] ) ) : '';
+        $args = [
+            'post_type'      => 'product',
+            'posts_per_page' => 20,
+            'paged'          => $this->get_pagenum(),
+            'tax_query'      => [
+                [
+                    'taxonomy' => 'product_type',
+                    'field'    => 'slug',
+                    'terms'    => 'auction',
+                ],
+            ],
+            'meta_query'     => [],
+        ];
+        $now = current_time( 'mysql' );
+        if ( 'upcoming' === $status ) {
+            $args['meta_query'][] = [
+                'key'     => '_auction_start',
+                'value'   => $now,
+                'compare' => '>',
+                'type'    => 'DATETIME',
+            ];
+        } elseif ( 'ended' === $status ) {
+            $args['meta_query'][] = [
+                'key'     => '_auction_end',
+                'value'   => $now,
+                'compare' => '<',
+                'type'    => 'DATETIME',
+            ];
+        } elseif ( 'active' === $status ) {
+            $args['meta_query'][] = [
+                'key'     => '_auction_start',
+                'value'   => $now,
+                'compare' => '<=',
+                'type'    => 'DATETIME',
+            ];
+            $args['meta_query'][] = [
+                'key'     => '_auction_end',
+                'value'   => $now,
+                'compare' => '>=',
+                'type'    => 'DATETIME',
+            ];
+        }
+
+        $query = new WP_Query( $args );
+        $items  = [];
+        foreach ( $query->posts as $post ) {
+            $start = get_post_meta( $post->ID, '_auction_start', true );
+            $end   = get_post_meta( $post->ID, '_auction_end', true );
+            $items[] = [
+                'ID'    => $post->ID,
+                'title' => $post->post_title,
+                'start' => $start,
+                'end'   => $end,
+            ];
+        }
+        $this->items = $items;
+        $this->set_pagination_args( [
+            'total_items' => $query->found_posts,
+            'per_page'    => 20,
+            'total_pages' => $query->max_num_pages,
+        ] );
+    }
+
+    public function get_columns() {
+        return [
+            'title'  => __( 'Auction', 'wpam' ),
+            'start'  => __( 'Start', 'wpam' ),
+            'end'    => __( 'End', 'wpam' ),
+            'status' => __( 'Status', 'wpam' ),
+        ];
+    }
+
+    protected function column_title( $item ) {
+        $edit_link = get_edit_post_link( $item['ID'] );
+        $view_bids = add_query_arg(
+            [
+                'page'       => 'wpam-bids',
+                'auction_id' => $item['ID'],
+            ],
+            admin_url( 'admin.php' )
+        );
+        $title   = '<strong><a href="' . esc_url( $edit_link ) . '">' . esc_html( $item['title'] ) . '</a></strong>';
+        $actions = [
+            'edit' => '<a href="' . esc_url( $edit_link ) . '">' . __( 'Edit', 'wpam' ) . '</a>',
+            'bids' => '<a href="' . esc_url( $view_bids ) . '">' . __( 'View Bids', 'wpam' ) . '</a>',
+        ];
+        return $title . $this->row_actions( $actions );
+    }
+
+    protected function column_status( $item ) {
+        $now   = current_time( 'timestamp' );
+        $start = strtotime( $item['start'] );
+        $end   = strtotime( $item['end'] );
+        if ( $start > $now ) {
+            return __( 'Upcoming', 'wpam' );
+        } elseif ( $end < $now ) {
+            return __( 'Ended', 'wpam' );
+        } else {
+            return __( 'Active', 'wpam' );
+        }
+    }
+
+    public function get_views() {
+        $current  = isset( $_GET['status'] ) ? sanitize_text_field( wp_unslash( $_GET['status'] ) ) : '';
+        $base_url = remove_query_arg( [ 'status', 'paged' ] );
+        $views    = [];
+        $views['all']      = sprintf( '<a href="%s"%s>%s</a>', esc_url( $base_url ), $current === '' ? ' class="current"' : '', __( 'All', 'wpam' ) );
+        $views['upcoming'] = sprintf( '<a href="%s"%s>%s</a>', esc_url( add_query_arg( 'status', 'upcoming', $base_url ) ), $current === 'upcoming' ? ' class="current"' : '', __( 'Upcoming', 'wpam' ) );
+        $views['active']   = sprintf( '<a href="%s"%s>%s</a>', esc_url( add_query_arg( 'status', 'active', $base_url ) ), $current === 'active' ? ' class="current"' : '', __( 'Active', 'wpam' ) );
+        $views['ended']    = sprintf( '<a href="%s"%s>%s</a>', esc_url( add_query_arg( 'status', 'ended', $base_url ) ), $current === 'ended' ? ' class="current"' : '', __( 'Ended', 'wpam' ) );
+        return $views;
+    }
+
+    public function no_items() {
+        _e( 'No auctions found.', 'wpam' );
+    }
+
+    protected function column_default( $item, $column_name ) {
+        return isset( $item[ $column_name ] ) ? esc_html( $item[ $column_name ] ) : '';
+    }
+}

--- a/admin/class-wpam-bids-table.php
+++ b/admin/class-wpam-bids-table.php
@@ -1,0 +1,53 @@
+<?php
+if ( ! class_exists( 'WP_List_Table' ) ) {
+    require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+}
+
+class WPAM_Bids_Table extends WP_List_Table {
+    protected $auction_id;
+
+    public function __construct( $auction_id ) {
+        $this->auction_id = absint( $auction_id );
+        parent::__construct();
+    }
+
+    public function prepare_items() {
+        global $wpdb;
+        $table   = $wpdb->prefix . 'wc_auction_bids';
+        $results = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $table WHERE auction_id = %d ORDER BY bid_time DESC", $this->auction_id ), ARRAY_A );
+        $this->items = $results;
+        $this->set_pagination_args( [
+            'total_items' => count( $results ),
+            'per_page'    => 50,
+            'total_pages' => 1,
+        ] );
+    }
+
+    public function get_columns() {
+        return [
+            'user'     => __( 'User', 'wpam' ),
+            'amount'   => __( 'Amount', 'wpam' ),
+            'bid_time' => __( 'Bid Time', 'wpam' ),
+        ];
+    }
+
+    protected function column_user( $item ) {
+        $user = get_user_by( 'id', $item['user_id'] );
+        return $user ? esc_html( $user->display_name ) : __( 'Unknown', 'wpam' );
+    }
+
+    protected function column_amount( $item ) {
+        if ( function_exists( 'wc_price' ) ) {
+            return wc_price( $item['bid_amount'] );
+        }
+        return esc_html( $item['bid_amount'] );
+    }
+
+    protected function column_default( $item, $column_name ) {
+        return isset( $item[ $column_name ] ) ? esc_html( $item[ $column_name ] ) : '';
+    }
+
+    public function no_items() {
+        _e( 'No bids found.', 'wpam' );
+    }
+}


### PR DESCRIPTION
## Summary
- add WP_List_Table classes for auctions and bids
- create admin submenu pages for listings, bids, and settings
- implement settings fields for Twilio integration

## Testing
- `php -l admin/class-wpam-admin.php`
- `php -l admin/class-wpam-auctions-table.php`
- `php -l admin/class-wpam-bids-table.php`


------
https://chatgpt.com/codex/tasks/task_e_6888b33ce4e48333b64b4881287c5d0c