### PR TITLE
Add WooCommerce watchlist account tab

### DIFF
--- a/includes/class-wpam-install.php
+++ b/includes/class-wpam-install.php
@@ -28,6 +28,9 @@ class WPAM_Install {
             KEY user_id (user_id)
         ) $charset_collate;";
         dbDelta( $watchlist_sql );
+
+        add_rewrite_endpoint( 'watchlist', EP_ROOT | EP_PAGES );
+        flush_rewrite_rules();
     }
 }
 

--- a/includes/class-wpam-watchlist.php
+++ b/includes/class-wpam-watchlist.php
@@ -3,6 +3,12 @@ class WPAM_Watchlist {
     public function __construct() {
         add_action( 'wp_ajax_wpam_toggle_watchlist', [ $this, 'toggle_watchlist' ] );
         add_action( 'wp_ajax_nopriv_wpam_toggle_watchlist', [ $this, 'toggle_watchlist' ] );
+
+        add_action( 'wp_ajax_wpam_get_watchlist', [ $this, 'get_watchlist' ] );
+
+        add_action( 'init', [ $this, 'add_account_endpoint' ] );
+        add_filter( 'woocommerce_account_menu_items', [ $this, 'add_account_menu_item' ] );
+        add_action( 'woocommerce_account_watchlist_endpoint', [ $this, 'render_account_page' ] );
     }
 
     public function toggle_watchlist() {
@@ -29,6 +35,61 @@ class WPAM_Watchlist {
             ], [ '%d', '%d' ] );
             wp_send_json_success( [ 'message' => __( 'Added to watchlist', 'wpam' ) ] );
         }
+    }
+
+    public function get_user_watchlist_items( $user_id ) {
+        global $wpdb;
+        $table        = $wpdb->prefix . 'wc_auction_watchlists';
+        $auction_ids  = $wpdb->get_col( $wpdb->prepare( "SELECT auction_id FROM $table WHERE user_id = %d", $user_id ) );
+
+        $items = [];
+        foreach ( $auction_ids as $auction_id ) {
+            $items[] = [
+                'id'    => $auction_id,
+                'title' => get_the_title( $auction_id ),
+                'url'   => get_permalink( $auction_id ),
+            ];
+        }
+
+        return $items;
+    }
+
+    public function get_watchlist() {
+        $user_id = get_current_user_id();
+        if ( ! $user_id ) {
+            wp_send_json_error( [ 'message' => __( 'Please login', 'wpam' ) ] );
+        }
+
+        wp_send_json_success( [ 'items' => $this->get_user_watchlist_items( $user_id ) ] );
+    }
+
+    public function add_account_endpoint() {
+        add_rewrite_endpoint( 'watchlist', EP_ROOT | EP_PAGES );
+    }
+
+    public function add_account_menu_item( $items ) {
+        $items['watchlist'] = __( 'Watchlist', 'wpam' );
+        return $items;
+    }
+
+    public function render_account_page() {
+        $user_id = get_current_user_id();
+        if ( ! $user_id ) {
+            echo '<p>' . esc_html__( 'Please login to view your watchlist.', 'wpam' ) . '</p>';
+            return;
+        }
+
+        $items = $this->get_user_watchlist_items( $user_id );
+        if ( empty( $items ) ) {
+            echo '<p>' . esc_html__( 'Your watchlist is empty.', 'wpam' ) . '</p>';
+            return;
+        }
+
+        echo '<ul class="wpam-watchlist-items">';
+        foreach ( $items as $item ) {
+            echo '<li><a href="' . esc_url( $item['url'] ) . '">' . esc_html( $item['title'] ) . '</a></li>';
+        }
+        echo '</ul>';
     }
 }
 


### PR DESCRIPTION
## Summary
- support fetching watchlist items via new Ajax endpoint
- register `watchlist` endpoint in WooCommerce My Account area
- list user's watchlist items on their account page
- flush rewrite rules on activation

## Testing
- `php -l includes/class-wpam-watchlist.php`
- `php -l includes/class-wpam-install.php`


------
https://chatgpt.com/codex/tasks/task_e_6888b34150388333848229811a3abcbe