### PR TITLE
Add auction start/end cron handling

### DIFF
--- a/includes/class-wpam-auction.php
+++ b/includes/class-wpam-auction.php
@@ -13,6 +13,8 @@ class WPAM_Auction {
         add_filter( 'woocommerce_product_data_tabs', [ $this, 'add_product_data_tab' ] );
         add_action( 'woocommerce_product_data_panels', [ $this, 'add_product_data_fields' ] );
         add_action( 'woocommerce_process_product_meta_auction', [ $this, 'save_product_data' ] );
+        add_action( 'wpam_auction_start', [ $this, 'handle_auction_start' ] );
+        add_action( 'wpam_auction_end', [ $this, 'handle_auction_end' ] );
     }
 
     public function register_product_type() {
@@ -49,11 +51,72 @@ class WPAM_Auction {
     }
 
     public function save_product_data( $post_id ) {
+        $start = null;
+        $end   = null;
+
         if ( isset( $_POST['_auction_start'] ) ) {
-            update_post_meta( $post_id, '_auction_start', wc_clean( $_POST['_auction_start'] ) );
+            $start = wc_clean( wp_unslash( $_POST['_auction_start'] ) );
+            update_post_meta( $post_id, '_auction_start', $start );
+        } else {
+            $start = get_post_meta( $post_id, '_auction_start', true );
         }
+
         if ( isset( $_POST['_auction_end'] ) ) {
-            update_post_meta( $post_id, '_auction_end', wc_clean( $_POST['_auction_end'] ) );
+            $end = wc_clean( wp_unslash( $_POST['_auction_end'] ) );
+            update_post_meta( $post_id, '_auction_end', $end );
+        } else {
+            $end = get_post_meta( $post_id, '_auction_end', true );
         }
+
+        $this->schedule_events( $post_id, $start, $end );
+    }
+
+    private function schedule_events( $post_id, $start, $end ) {
+        $now = current_time( 'timestamp' );
+
+        if ( $start ) {
+            $start_ts = strtotime( $start );
+            if ( $start_ts && $start_ts > $now ) {
+                wp_clear_scheduled_hook( 'wpam_auction_start', [ $post_id ] );
+                wp_schedule_single_event( $start_ts, 'wpam_auction_start', [ $post_id ] );
+            }
+        }
+
+        if ( $end ) {
+            $end_ts = strtotime( $end );
+            if ( $end_ts && $end_ts > $now ) {
+                wp_clear_scheduled_hook( 'wpam_auction_end', [ $post_id ] );
+                wp_schedule_single_event( $end_ts, 'wpam_auction_end', [ $post_id ] );
+            }
+        }
+    }
+
+    public function handle_auction_start( $auction_id ) {
+        update_post_meta( $auction_id, '_auction_status', 'active' );
+    }
+
+    public function handle_auction_end( $auction_id ) {
+        global $wpdb;
+
+        $table = $wpdb->prefix . 'wc_auction_bids';
+        $row   = $wpdb->get_row( $wpdb->prepare( "SELECT user_id, bid_amount FROM {$table} WHERE auction_id = %d ORDER BY bid_amount DESC, bid_time ASC LIMIT 1", $auction_id ) );
+
+        if ( $row ) {
+            update_post_meta( $auction_id, '_auction_winner', $row->user_id );
+
+            $order = wc_create_order( [ 'customer_id' => $row->user_id ] );
+            if ( ! is_wp_error( $order ) ) {
+                $product = wc_get_product( $auction_id );
+                if ( $product ) {
+                    $order->add_product( $product, 1, [
+                        'subtotal' => $row->bid_amount,
+                        'total'    => $row->bid_amount,
+                    ] );
+                    $order->calculate_totals();
+                }
+            }
+        }
+
+        update_post_meta( $auction_id, '_auction_status', 'closed' );
     }
 }

--- a/includes/class-wpam-install.php
+++ b/includes/class-wpam-install.php
@@ -31,6 +31,35 @@ class WPAM_Install {
 
         add_rewrite_endpoint( 'watchlist', EP_ROOT | EP_PAGES );
         flush_rewrite_rules();
+
+        // Schedule cron events for existing auctions
+        $auctions = get_posts(
+            [
+                'post_type'      => 'product',
+                'posts_per_page' => -1,
+                'meta_query'     => [
+                    [ 'key' => '_auction_start', 'compare' => 'EXISTS' ],
+                ],
+                'fields'         => 'ids',
+            ]
+        );
+
+        foreach ( $auctions as $auction_id ) {
+            $start = get_post_meta( $auction_id, '_auction_start', true );
+            $end   = get_post_meta( $auction_id, '_auction_end', true );
+
+            $start_ts = $start ? strtotime( $start ) : false;
+            $end_ts   = $end ? strtotime( $end ) : false;
+            $now      = current_time( 'timestamp' );
+
+            if ( $start_ts && $start_ts > $now ) {
+                wp_schedule_single_event( $start_ts, 'wpam_auction_start', [ $auction_id ] );
+            }
+
+            if ( $end_ts && $end_ts > $now ) {
+                wp_schedule_single_event( $end_ts, 'wpam_auction_end', [ $auction_id ] );
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- hook into product save to schedule single events for auction start and end
- update installer to schedule events for existing auctions on activation
- add handlers that activate and close auctions, select a winner and create an order

## Testing
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_6888babe9c7c83339f774066ff82785d