### PR TITLE
Add extra auction field help notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ WP Auction Manager is a WordPress plugin that extends WooCommerce by adding an "
 3. Set the auction start and end dates in the Auction tab.
 4. Publish the product to start the auction at the scheduled time.
 
+### Auction options
+
+When editing an auction product you can configure additional options in the **Auction** tab:
+
+- **Auction Type** – choose Standard, Reverse or Sealed.
+- **Reserve Price** – minimum price required for the auction to have a winner.
+- **Buy Now Price** – optional instant purchase price.
+- **Minimum Increment** – smallest allowed increase between bids.
+- **Soft Close Minutes** – extend the end time if a bid is placed near closing.
+- **Auto Relist** – automatically relist when no winning bid exists.
+- **Max Bids Per User** – limit how many bids each user can place.
+- **Auction Fee** – extra fee added to the winning bid.
+
 ## Folder structure
 
 ```text

--- a/includes/class-wpam-auction.php
+++ b/includes/class-wpam-auction.php
@@ -35,16 +35,96 @@ class WPAM_Auction {
 
     public function add_product_data_fields() {
         echo '<div id="auction_product_data" class="panel woocommerce_options_panel hidden">';
+
+        woocommerce_wp_select([
+            'id'          => '_auction_type',
+            'label'       => __( 'Auction Type', 'wpam' ),
+            'description' => __( 'Select the bidding style for this auction.', 'wpam' ),
+            'desc_tip'    => true,
+            'options'     => [
+                'standard' => __( 'Standard', 'wpam' ),
+                'reverse'  => __( 'Reverse', 'wpam' ),
+                'sealed'   => __( 'Sealed', 'wpam' ),
+            ],
+        ]);
+
         woocommerce_wp_text_input([
             'id'          => '_auction_start',
             'label'       => __( 'Start Date', 'wpam' ),
             'type'        => 'datetime-local',
+            'description' => __( 'When bidding opens.', 'wpam' ),
+            'desc_tip'    => true,
         ]);
+
         woocommerce_wp_text_input([
             'id'          => '_auction_end',
             'label'       => __( 'End Date', 'wpam' ),
             'type'        => 'datetime-local',
+            'description' => __( 'When the auction will close.', 'wpam' ),
+            'desc_tip'    => true,
         ]);
+
+        woocommerce_wp_text_input([
+            'id'          => '_auction_reserve',
+            'label'       => __( 'Reserve Price', 'wpam' ),
+            'description' => __( 'Minimum price required for a valid sale.', 'wpam' ),
+            'desc_tip'    => true,
+            'type'        => 'number',
+            'custom_attributes' => [ 'step' => '0.01', 'min' => '0' ],
+        ]);
+
+        woocommerce_wp_text_input([
+            'id'          => '_auction_buy_now',
+            'label'       => __( 'Buy Now Price', 'wpam' ),
+            'description' => __( 'Optional instant purchase amount.', 'wpam' ),
+            'desc_tip'    => true,
+            'type'        => 'number',
+            'custom_attributes' => [ 'step' => '0.01', 'min' => '0' ],
+        ]);
+
+        woocommerce_wp_text_input([
+            'id'          => '_auction_increment',
+            'label'       => __( 'Minimum Increment', 'wpam' ),
+            'description' => __( 'Lowest amount a new bid must increase by.', 'wpam' ),
+            'desc_tip'    => true,
+            'type'        => 'number',
+            'custom_attributes' => [ 'step' => '0.01', 'min' => '0' ],
+        ]);
+
+        woocommerce_wp_text_input([
+            'id'          => '_auction_soft_close',
+            'label'       => __( 'Soft Close Minutes', 'wpam' ),
+            'description' => __( 'Number of minutes to extend if a bid is placed near the end.', 'wpam' ),
+            'desc_tip'    => true,
+            'type'        => 'number',
+            'custom_attributes' => [ 'step' => '1', 'min' => '0' ],
+        ]);
+
+        woocommerce_wp_checkbox([
+            'id'          => '_auction_auto_relist',
+            'label'       => __( 'Auto Relist', 'wpam' ),
+            'description' => __( 'Relist automatically when there is no winner.', 'wpam' ),
+            'desc_tip'    => true,
+        ]);
+
+        woocommerce_wp_text_input([
+            'id'          => '_auction_max_bids',
+            'label'       => __( 'Max Bids Per User', 'wpam' ),
+            'description' => __( 'Limit how many bids each user may place.', 'wpam' ),
+            'desc_tip'    => true,
+            'type'        => 'number',
+            'custom_attributes' => [ 'step' => '1', 'min' => '0' ],
+        ]);
+
+        woocommerce_wp_text_input([
+            'id'          => '_auction_fee',
+            'label'       => __( 'Auction Fee', 'wpam' ),
+            'description' => __( 'Extra fee added to the winning bid.', 'wpam' ),
+            'desc_tip'    => true,
+            'type'        => 'number',
+            'custom_attributes' => [ 'step' => '0.01', 'min' => '0' ],
+        ]);
+
         echo '</div>';
     }
 
@@ -54,6 +134,28 @@ class WPAM_Auction {
         }
         if ( isset( $_POST['_auction_end'] ) ) {
             update_post_meta( $post_id, '_auction_end', wc_clean( $_POST['_auction_end'] ) );
+        }
+
+        $fields = [
+            '_auction_type',
+            '_auction_reserve',
+            '_auction_buy_now',
+            '_auction_increment',
+            '_auction_soft_close',
+            '_auction_auto_relist',
+            '_auction_max_bids',
+            '_auction_fee',
+        ];
+
+        foreach ( $fields as $field ) {
+            if ( isset( $_POST[ $field ] ) ) {
+                $value = wc_clean( $_POST[ $field ] );
+                update_post_meta( $post_id, $field, $value );
+            } else {
+                if ( '_auction_auto_relist' === $field ) {
+                    update_post_meta( $post_id, $field, 'no' );
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- expand auction product form with help notes for each option

## Testing
- `php -l includes/class-wpam-auction.php`


------
https://chatgpt.com/codex/tasks/task_e_6888babb04748333bcdb2993d0c871f8