### PR TITLE
Add My Bids and Auctions Won pages

### DIFF
--- a/includes/class-wpam-bid.php
+++ b/includes/class-wpam-bid.php
@@ -3,6 +3,11 @@ class WPAM_Bid {
     public function __construct() {
         add_action( 'wp_ajax_wpam_place_bid', [ $this, 'place_bid' ] );
         add_action( 'wp_ajax_nopriv_wpam_place_bid', [ $this, 'place_bid' ] );
+
+        add_action( 'init', [ $this, 'add_account_endpoints' ] );
+        add_filter( 'woocommerce_account_menu_items', [ $this, 'add_account_menu_items' ] );
+        add_action( 'woocommerce_account_my-bids_endpoint', [ $this, 'render_my_bids_page' ] );
+        add_action( 'woocommerce_account_auctions-won_endpoint', [ $this, 'render_auctions_won_page' ] );
     }
 
     public function place_bid() {
@@ -52,5 +57,82 @@ class WPAM_Bid {
         );
 
         wp_send_json_success( [ 'message' => __( 'Bid received', 'wpam' ) ] );
+    }
+
+    public function add_account_endpoints() {
+        add_rewrite_endpoint( 'my-bids', EP_ROOT | EP_PAGES );
+        add_rewrite_endpoint( 'auctions-won', EP_ROOT | EP_PAGES );
+    }
+
+    public function add_account_menu_items( $items ) {
+        $items['my-bids']      = __( 'My Bids', 'wpam' );
+        $items['auctions-won'] = __( 'Auctions Won', 'wpam' );
+        return $items;
+    }
+
+    public function render_my_bids_page() {
+        $user_id = get_current_user_id();
+        $bids    = $user_id ? $this->get_user_bids( $user_id ) : [];
+        include WPAM_PLUGIN_DIR . 'templates/my-bids.php';
+    }
+
+    public function render_auctions_won_page() {
+        $user_id  = get_current_user_id();
+        $auctions = $user_id ? $this->get_user_won_auctions( $user_id ) : [];
+        include WPAM_PLUGIN_DIR . 'templates/auctions-won.php';
+    }
+
+    private function get_user_bids( $user_id ) {
+        global $wpdb;
+        $table = $wpdb->prefix . 'wc_auction_bids';
+
+        $rows = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT auction_id, bid_amount, bid_time FROM $table WHERE user_id = %d ORDER BY bid_time DESC",
+                $user_id
+            ),
+            ARRAY_A
+        );
+
+        $bids = [];
+        foreach ( $rows as $row ) {
+            $bids[] = [
+                'id'     => intval( $row['auction_id'] ),
+                'title'  => get_the_title( $row['auction_id'] ),
+                'url'    => get_permalink( $row['auction_id'] ),
+                'amount' => floatval( $row['bid_amount'] ),
+                'time'   => mysql2date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $row['bid_time'] ),
+            ];
+        }
+
+        return $bids;
+    }
+
+    private function get_user_won_auctions( $user_id ) {
+        global $wpdb;
+        $table = $wpdb->prefix . 'wc_auction_bids';
+
+        $auction_ids = $wpdb->get_col(
+            $wpdb->prepare(
+                "SELECT DISTINCT b1.auction_id FROM $table b1 LEFT JOIN $table b2 ON b1.auction_id = b2.auction_id AND b2.bid_amount > b1.bid_amount WHERE b1.user_id = %d AND b2.id IS NULL",
+                $user_id
+            )
+        );
+
+        $won = [];
+        $now = current_time( 'timestamp' );
+        foreach ( $auction_ids as $auction_id ) {
+            $end   = get_post_meta( $auction_id, '_auction_end', true );
+            $end_ts = $end ? strtotime( $end ) : 0;
+            if ( $end_ts && $end_ts <= $now ) {
+                $won[] = [
+                    'id'    => intval( $auction_id ),
+                    'title' => get_the_title( $auction_id ),
+                    'url'   => get_permalink( $auction_id ),
+                ];
+            }
+        }
+
+        return $won;
     }
 }

--- a/includes/class-wpam-install.php
+++ b/includes/class-wpam-install.php
@@ -30,6 +30,8 @@ class WPAM_Install {
         dbDelta( $watchlist_sql );
 
         add_rewrite_endpoint( 'watchlist', EP_ROOT | EP_PAGES );
+        add_rewrite_endpoint( 'my-bids', EP_ROOT | EP_PAGES );
+        add_rewrite_endpoint( 'auctions-won', EP_ROOT | EP_PAGES );
         flush_rewrite_rules();
     }
 }

--- a/templates/auctions-won.php
+++ b/templates/auctions-won.php
@@ -1,0 +1,21 @@
+<?php
+get_header();
+?>
+<div class="wpam-auctions-won">
+    <h1><?php _e( 'Auctions Won', 'wpam' ); ?></h1>
+    <?php if ( ! empty( $auctions ) ) : ?>
+        <ul class="wpam-won-items">
+            <?php foreach ( $auctions as $auction ) : ?>
+                <li>
+                    <a href="<?php echo esc_url( $auction['url'] ); ?>">
+                        <?php echo esc_html( $auction['title'] ); ?>
+                    </a>
+                </li>
+            <?php endforeach; ?>
+        </ul>
+    <?php else : ?>
+        <p><?php _e( 'You have not won any auctions yet.', 'wpam' ); ?></p>
+    <?php endif; ?>
+</div>
+<?php
+get_footer();

--- a/templates/my-bids.php
+++ b/templates/my-bids.php
@@ -1,0 +1,23 @@
+<?php
+get_header();
+?>
+<div class="wpam-my-bids">
+    <h1><?php _e( 'My Bids', 'wpam' ); ?></h1>
+    <?php if ( ! empty( $bids ) ) : ?>
+        <ul class="wpam-bid-items">
+            <?php foreach ( $bids as $bid ) : ?>
+                <li>
+                    <a href="<?php echo esc_url( $bid['url'] ); ?>">
+                        <?php echo esc_html( $bid['title'] ); ?>
+                    </a>
+                    - <?php echo esc_html( wc_price( $bid['amount'] ) ); ?>
+                    - <?php echo esc_html( $bid['time'] ); ?>
+                </li>
+            <?php endforeach; ?>
+        </ul>
+    <?php else : ?>
+        <p><?php _e( 'You have not placed any bids yet.', 'wpam' ); ?></p>
+    <?php endif; ?>
+</div>
+<?php
+get_footer();


### PR DESCRIPTION
## Summary
- add account endpoints for `my-bids` and `auctions-won`
- query wc_auction_bids table to list placed bids and won auctions
- register menu links in My Account
- create templates for new account pages
- register endpoints on plugin activation

## Testing
- `php -l includes/class-wpam-bid.php`
- `php -l includes/class-wpam-install.php`
- `php -l templates/my-bids.php`
- `php -l templates/auctions-won.php`

------
https://chatgpt.com/codex/tasks/task_e_6888bad6e9948333aed47b4203937868