### PR TITLE
Add frontend Q&A and admin moderation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,5 @@
 - Implemented basic bid placement storing bids in custom table.
 - Added watchlist table and AJAX toggle handler.
 - Provided public scripts and templates for bidding and watchlist controls.
+- Introduced messages table with frontend Q&A and admin moderation screen.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # WP Auction Manager
 
 WP Auction Manager is a WordPress plugin that extends WooCommerce by adding an "Auction" product type. Store owners can schedule auctions, accept bids and let users maintain a watchlist. Bids and watchlists are stored in custom database tables.
+The plugin also supports a question and answer thread on each auction so potential bidders can communicate with the seller.
 
 ## Installation
 

--- a/admin/class-wpam-admin.php
+++ b/admin/class-wpam-admin.php
@@ -35,6 +35,15 @@ class WPAM_Admin {
 
         add_submenu_page(
             'wpam-auctions',
+            __( 'Messages', 'wpam' ),
+            __( 'Messages', 'wpam' ),
+            'manage_options',
+            'wpam-messages',
+            [ $this, 'render_messages_page' ]
+        );
+
+        add_submenu_page(
+            'wpam-auctions',
             __( 'Integrations', 'wpam' ),
             __( 'Settings', 'wpam' ),
             'manage_options',
@@ -119,6 +128,29 @@ class WPAM_Admin {
         echo '<form method="get">';
         echo '<input type="hidden" name="page" value="wpam-bids" />';
         echo '<input type="hidden" name="auction_id" value="' . esc_attr( $auction_id ) . '" />';
+        $table->display();
+        echo '</form></div>';
+    }
+
+    public function render_messages_page() {
+        require_once WPAM_PLUGIN_DIR . 'admin/class-wpam-messages-table.php';
+
+        if ( isset( $_GET['action'], $_GET['message'] ) && in_array( $_GET['action'], [ 'approve', 'unapprove' ], true ) ) {
+            $message_id = absint( $_GET['message'] );
+            check_admin_referer( 'wpam_toggle_message_' . $message_id );
+            global $wpdb;
+            $table = $wpdb->prefix . 'wc_auction_messages';
+            $approved = 'approve' === $_GET['action'] ? 1 : 0;
+            $wpdb->update( $table, [ 'approved' => $approved ], [ 'id' => $message_id ], [ '%d' ], [ '%d' ] );
+            echo '<div class="updated"><p>' . esc_html__( 'Message updated.', 'wpam' ) . '</p></div>';
+        }
+
+        $table = new WPAM_Messages_Table();
+        $table->prepare_items();
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__( 'Auction Messages', 'wpam' ) . '</h1>';
+        echo '<form method="get">';
+        echo '<input type="hidden" name="page" value="wpam-messages" />';
         $table->display();
         echo '</form></div>';
     }

--- a/admin/class-wpam-messages-table.php
+++ b/admin/class-wpam-messages-table.php
@@ -1,0 +1,57 @@
+<?php
+if ( ! class_exists( 'WP_List_Table' ) ) {
+    require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+}
+
+class WPAM_Messages_Table extends WP_List_Table {
+    public function prepare_items() {
+        global $wpdb;
+        $table   = $wpdb->prefix . 'wc_auction_messages';
+        $results = $wpdb->get_results( "SELECT * FROM $table ORDER BY created_at DESC", ARRAY_A );
+        $this->items = $results;
+        $this->set_pagination_args( [
+            'total_items' => count( $results ),
+            'per_page'    => 50,
+            'total_pages' => 1,
+        ] );
+    }
+
+    public function get_columns() {
+        return [
+            'auction' => __( 'Auction', 'wpam' ),
+            'user'    => __( 'User', 'wpam' ),
+            'message' => __( 'Message', 'wpam' ),
+            'status'  => __( 'Status', 'wpam' ),
+            'date'    => __( 'Date', 'wpam' ),
+        ];
+    }
+
+    protected function column_auction( $item ) {
+        $title = get_the_title( $item['auction_id'] );
+        return $title ? esc_html( $title ) : sprintf( '#%d', $item['auction_id'] );
+    }
+
+    protected function column_user( $item ) {
+        $user = get_user_by( 'id', $item['user_id'] );
+        return $user ? esc_html( $user->display_name ) : __( 'Unknown', 'wpam' );
+    }
+
+    protected function column_message( $item ) {
+        $text    = wp_trim_words( $item['message'], 10 );
+        $actions = [];
+        if ( $item['approved'] ) {
+            $actions['unapprove'] = sprintf( '<a href="%s">%s</a>', esc_url( wp_nonce_url( add_query_arg( [ 'action' => 'unapprove', 'message' => $item['id'] ], admin_url( 'admin.php?page=wpam-messages' ) ), 'wpam_toggle_message_' . $item['id'] ) ), __( 'Unapprove', 'wpam' ) );
+        } else {
+            $actions['approve'] = sprintf( '<a href="%s">%s</a>', esc_url( wp_nonce_url( add_query_arg( [ 'action' => 'approve', 'message' => $item['id'] ], admin_url( 'admin.php?page=wpam-messages' ) ), 'wpam_toggle_message_' . $item['id'] ) ), __( 'Approve', 'wpam' ) );
+        }
+        return esc_html( $text ) . $this->row_actions( $actions );
+    }
+
+    protected function column_status( $item ) {
+        return $item['approved'] ? __( 'Approved', 'wpam' ) : __( 'Pending', 'wpam' );
+    }
+
+    protected function column_default( $item, $column_name ) {
+        return isset( $item[ $column_name ] ) ? esc_html( $item[ $column_name ] ) : '';
+    }
+}

--- a/includes/class-wpam-install.php
+++ b/includes/class-wpam-install.php
@@ -29,6 +29,22 @@ class WPAM_Install {
         ) $charset_collate;";
         dbDelta( $watchlist_sql );
 
+        // Messages table
+        $messages_table = $wpdb->prefix . 'wc_auction_messages';
+        $messages_sql   = "CREATE TABLE IF NOT EXISTS $messages_table (
+            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+            auction_id bigint(20) unsigned NOT NULL,
+            user_id bigint(20) unsigned NOT NULL,
+            message text NOT NULL,
+            parent_id bigint(20) unsigned NOT NULL DEFAULT 0,
+            approved tinyint(1) NOT NULL DEFAULT 0,
+            created_at datetime NOT NULL,
+            PRIMARY KEY  (id),
+            KEY auction_id (auction_id),
+            KEY user_id (user_id)
+        ) $charset_collate;";
+        dbDelta( $messages_sql );
+
         add_rewrite_endpoint( 'watchlist', EP_ROOT | EP_PAGES );
         flush_rewrite_rules();
     }

--- a/includes/class-wpam-loader.php
+++ b/includes/class-wpam-loader.php
@@ -5,6 +5,7 @@ class WPAM_Loader {
         require_once WPAM_PLUGIN_DIR . 'includes/class-wpam-auction.php';
         require_once WPAM_PLUGIN_DIR . 'includes/class-wpam-bid.php';
         require_once WPAM_PLUGIN_DIR . 'includes/class-wpam-watchlist.php';
+        require_once WPAM_PLUGIN_DIR . 'includes/class-wpam-messages.php';
         require_once WPAM_PLUGIN_DIR . 'admin/class-wpam-admin.php';
         require_once WPAM_PLUGIN_DIR . 'public/class-wpam-public.php';
 
@@ -12,6 +13,7 @@ class WPAM_Loader {
         new WPAM_Auction();
         new WPAM_Bid();
         new WPAM_Watchlist();
+        new WPAM_Messages();
         new WPAM_Admin();
         new WPAM_Public();
     }

--- a/includes/class-wpam-messages.php
+++ b/includes/class-wpam-messages.php
@@ -1,0 +1,64 @@
+<?php
+class WPAM_Messages {
+    public function __construct() {
+        add_action( 'wp_ajax_wpam_submit_question', [ $this, 'submit_question' ] );
+        add_action( 'wp_ajax_nopriv_wpam_submit_question', [ $this, 'submit_question' ] );
+        add_action( 'wp_ajax_wpam_get_messages', [ $this, 'get_messages' ] );
+        add_action( 'wp_ajax_nopriv_wpam_get_messages', [ $this, 'get_messages' ] );
+    }
+
+    public function submit_question() {
+        check_ajax_referer( 'wpam_submit_question', 'nonce' );
+
+        if ( empty( $_POST['auction_id'] ) || empty( $_POST['message'] ) ) {
+            wp_send_json_error( [ 'message' => __( 'Invalid data', 'wpam' ) ] );
+        }
+
+        $user_id = get_current_user_id();
+        if ( ! $user_id ) {
+            wp_send_json_error( [ 'message' => __( 'Please login', 'wpam' ) ] );
+        }
+
+        global $wpdb;
+        $table = $wpdb->prefix . 'wc_auction_messages';
+
+        $wpdb->insert(
+            $table,
+            [
+                'auction_id' => absint( $_POST['auction_id'] ),
+                'user_id'    => $user_id,
+                'message'    => sanitize_textarea_field( wp_unslash( $_POST['message'] ) ),
+                'parent_id'  => isset( $_POST['parent_id'] ) ? absint( $_POST['parent_id'] ) : 0,
+                'approved'   => 0,
+                'created_at' => current_time( 'mysql' ),
+            ],
+            [ '%d', '%d', '%s', '%d', '%d', '%s' ]
+        );
+
+        wp_send_json_success( [ 'message' => __( 'Message submitted for review.', 'wpam' ) ] );
+    }
+
+    public function get_messages() {
+        if ( empty( $_POST['auction_id'] ) ) {
+            wp_send_json_error( [ 'message' => __( 'Invalid auction', 'wpam' ) ] );
+        }
+
+        global $wpdb;
+        $table  = $wpdb->prefix . 'wc_auction_messages';
+        $results = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $table WHERE auction_id = %d AND approved = 1 ORDER BY created_at ASC", absint( $_POST['auction_id'] ) ), ARRAY_A );
+
+        $messages = [];
+        foreach ( $results as $row ) {
+            $user = get_user_by( 'id', $row['user_id'] );
+            $messages[] = [
+                'id'        => $row['id'],
+                'user'      => $user ? $user->display_name : __( 'Unknown', 'wpam' ),
+                'message'   => $row['message'],
+                'parent_id' => $row['parent_id'],
+                'date'      => $row['created_at'],
+            ];
+        }
+
+        wp_send_json_success( [ 'messages' => $messages ] );
+    }
+}

--- a/public/class-wpam-public.php
+++ b/public/class-wpam-public.php
@@ -15,5 +15,15 @@ class WPAM_Public {
                 'watchlist_nonce' => wp_create_nonce( 'wpam_toggle_watchlist' ),
             ]
         );
+
+        wp_enqueue_script( 'wpam-ajax-messages', WPAM_PLUGIN_URL . 'public/js/ajax-messages.js', [ 'jquery' ], WPAM_PLUGIN_VERSION, true );
+        wp_localize_script(
+            'wpam-ajax-messages',
+            'wpam_messages',
+            [
+                'ajax_url'      => admin_url( 'admin-ajax.php' ),
+                'message_nonce' => wp_create_nonce( 'wpam_submit_question' ),
+            ]
+        );
     }
 }

--- a/public/js/ajax-messages.js
+++ b/public/js/ajax-messages.js
@@ -1,0 +1,46 @@
+jQuery(function($){
+    function loadMessages(auctionId){
+        $.post(
+            wpam_messages.ajax_url,
+            {
+                action: 'wpam_get_messages',
+                auction_id: auctionId
+            },
+            function(res){
+                if(res.success){
+                    const list = $('.wpam-messages-list').empty();
+                    res.data.messages.forEach(function(msg){
+                        const item = $('<div class="wpam-message"></div>').text(msg.user + ': ' + msg.message);
+                        list.append(item);
+                    });
+                }
+            }
+        );
+    }
+
+    $('.wpam-message-button').on('click', function(e){
+        e.preventDefault();
+        const auctionId = $(this).data('auction-id');
+        const textarea = $(this).siblings('.wpam-message-input');
+        $.post(
+            wpam_messages.ajax_url,
+            {
+                action: 'wpam_submit_question',
+                auction_id: auctionId,
+                message: textarea.val(),
+                nonce: wpam_messages.message_nonce
+            },
+            function(res){
+                alert(res.data.message);
+                if(res.success){
+                    textarea.val('');
+                    loadMessages(auctionId);
+                }
+            }
+        );
+    });
+
+    if($('.wpam-message-button').length){
+        loadMessages($('.wpam-message-button').data('auction-id'));
+    }
+});

--- a/templates/single-auction.php
+++ b/templates/single-auction.php
@@ -14,6 +14,20 @@ get_header();
     <button class="wpam-watchlist-button" data-auction-id="<?php the_ID(); ?>">
         <?php _e( 'Toggle Watchlist', 'wpam' ); ?>
     </button>
+
+    <div class="wpam-messages">
+        <h2><?php esc_html_e( 'Questions & Answers', 'wpam' ); ?></h2>
+        <div class="wpam-messages-list"></div>
+        <?php if ( is_user_logged_in() ) : ?>
+            <textarea class="wpam-message-input" rows="3"></textarea>
+            <?php wp_nonce_field( 'wpam_submit_question', 'wpam_message_nonce', false ); ?>
+            <button class="wpam-message-button" data-auction-id="<?php the_ID(); ?>">
+                <?php esc_html_e( 'Submit Question', 'wpam' ); ?>
+            </button>
+        <?php else : ?>
+            <p><?php esc_html_e( 'Please login to ask a question.', 'wpam' ); ?></p>
+        <?php endif; ?>
+    </div>
 </div>
 <?php
 get_footer();

--- a/uninstall.php
+++ b/uninstall.php
@@ -14,6 +14,7 @@ global $wpdb;
 $tables = [
     $wpdb->prefix . 'wc_auction_bids',
     $wpdb->prefix . 'wc_auction_watchlists',
+    $wpdb->prefix . 'wc_auction_messages',
 ];
 
 foreach ( $tables as $table ) {


### PR DESCRIPTION
## Summary
- create `wc_auction_messages` table on install
- implement `WPAM_Messages` AJAX class
- allow users to ask questions and view answers on the single auction template
- enqueue new JS for messaging
- add admin list table and submenu to moderate messages
- update uninstall routine and docs

## Testing
- `php -l includes/class-wpam-messages.php`
- `php -l admin/class-wpam-messages-table.php`
- `php -l admin/class-wpam-admin.php`
- `php -l includes/class-wpam-loader.php`
- `php -l includes/class-wpam-install.php`
- `php -l public/class-wpam-public.php`
- `php -l templates/single-auction.php`


------
https://chatgpt.com/codex/tasks/task_e_6888bae29f6c833396f030444e49f04c