### PR TITLE
Add auction winner order creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,5 @@
 - Implemented basic bid placement storing bids in custom table.
 - Added watchlist table and AJAX toggle handler.
 - Provided public scripts and templates for bidding and watchlist controls.
+- Automatic order creation and winner notifications on auction end.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
+## 1.0.1 - 2025-07-29
+- Automatic order creation and winner notifications on auction end.
+
 ## 1.0.0 - Initial release
 - Added custom auction product type with start and end date fields.
 - Implemented basic bid placement storing bids in custom table.
 - Added watchlist table and AJAX toggle handler.
 - Provided public scripts and templates for bidding and watchlist controls.
-- Automatic order creation and winner notifications on auction end.
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ WP Auction Manager is a WordPress plugin that extends WooCommerce by adding an "
 2. Choose **Auction** from the product type dropdown.
 3. Set the auction start and end dates in the Auction tab.
 4. Publish the product to start the auction at the scheduled time.
+5. When the auction ends, the highest bidder receives a WooCommerce order automatically.
 
 ## Folder structure
 

--- a/includes/class-wpam-auction.php
+++ b/includes/class-wpam-auction.php
@@ -13,6 +13,8 @@ class WPAM_Auction {
         add_filter( 'woocommerce_product_data_tabs', [ $this, 'add_product_data_tab' ] );
         add_action( 'woocommerce_product_data_panels', [ $this, 'add_product_data_fields' ] );
         add_action( 'woocommerce_process_product_meta_auction', [ $this, 'save_product_data' ] );
+
+        add_action( 'wpam_handle_auction_end', [ $this, 'handle_auction_end' ] );
     }
 
     public function register_product_type() {
@@ -53,7 +55,53 @@ class WPAM_Auction {
             update_post_meta( $post_id, '_auction_start', wc_clean( $_POST['_auction_start'] ) );
         }
         if ( isset( $_POST['_auction_end'] ) ) {
-            update_post_meta( $post_id, '_auction_end', wc_clean( $_POST['_auction_end'] ) );
+            $end = wc_clean( $_POST['_auction_end'] );
+            update_post_meta( $post_id, '_auction_end', $end );
+
+            $timestamp = strtotime( $end );
+            if ( $timestamp && $timestamp > time() ) {
+                wp_clear_scheduled_hook( 'wpam_handle_auction_end', [ $post_id ] );
+                wp_schedule_single_event( $timestamp, 'wpam_handle_auction_end', [ $post_id ] );
+            }
+        }
+    }
+
+    public function handle_auction_end( $auction_id ) {
+        global $wpdb;
+        $table   = $wpdb->prefix . 'wc_auction_bids';
+        $highest = $wpdb->get_row( $wpdb->prepare( "SELECT user_id, bid_amount FROM $table WHERE auction_id = %d ORDER BY bid_amount DESC LIMIT 1", $auction_id ), ARRAY_A );
+
+        if ( ! $highest ) {
+            return;
+        }
+
+        $user_id = intval( $highest['user_id'] );
+        $amount  = floatval( $highest['bid_amount'] );
+
+        $order = wc_create_order( [ 'customer_id' => $user_id ] );
+        $order->add_product( wc_get_product( $auction_id ), 1, [ 'subtotal' => $amount, 'total' => $amount ] );
+        $order->calculate_totals();
+
+        update_post_meta( $auction_id, '_auction_winner', $user_id );
+        update_post_meta( $auction_id, '_auction_order_id', $order->get_id() );
+        update_post_meta( $auction_id, '_auction_sold', '1' );
+        update_post_meta( $auction_id, '_stock_status', 'outofstock' );
+
+        $user   = get_user_by( 'id', $user_id );
+        $subject = sprintf( __( 'You won the auction: %s', 'wpam' ), get_the_title( $auction_id ) );
+        $message = sprintf( __( 'Congratulations! You won with a bid of %s. Order #%d has been created.', 'wpam' ), wc_price( $amount ), $order->get_id() );
+        wp_mail( $user->user_email, $subject, $message );
+
+        $sid   = get_option( 'wpam_twilio_sid' );
+        $token = get_option( 'wpam_twilio_token' );
+        $from  = get_option( 'wpam_twilio_from' );
+        $phone = get_user_meta( $user_id, 'billing_phone', true );
+
+        if ( $sid && $token && $from && $phone && class_exists( 'WPAM_Twilio_Provider' ) ) {
+            $twilio  = new WPAM_Twilio_Provider();
+            $sms_msg = sprintf( __( 'You won auction %s for %s', 'wpam' ), get_the_title( $auction_id ), wc_price( $amount ) );
+            $twilio->send( $phone, $sms_msg );
         }
     }
 }
+

--- a/wp-auction-manager.php
+++ b/wp-auction-manager.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: WP Auction Manager
 Description: Convert WooCommerce products into auctions with optional real-time and notification integrations.
-Version: 1.0.0
+Version: 1.0.1
 Author: Muzammil Hussain
 Author URI: https://muzammil.dev
 Uninstall: uninstall.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 
-define( 'WPAM_PLUGIN_VERSION', '1.0.0' );
+define( 'WPAM_PLUGIN_VERSION', '1.0.1' );
 define( 'WPAM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'WPAM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'WPAM_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
## Summary
- automatically schedule cron when auction end date is saved
- create WooCommerce order for the highest bidder when auction ends
- mark auction product as sold and notify winner via email or Twilio SMS
- bump plugin version
- document automatic order creation in README and changelog

## Testing
- `php -l includes/class-wpam-auction.php`
- `php -l wp-auction-manager.php`


------
https://chatgpt.com/codex/tasks/task_e_6888bb07a6dc8333a00062b82d415b76