### PR TITLE
Add login check for bids

### DIFF
--- a/includes/class-wpam-bid.php
+++ b/includes/class-wpam-bid.php
@@ -32,6 +32,10 @@ class WPAM_Bid {
         $bid        = floatval( $_POST['bid'] );
         $user_id    = get_current_user_id();
 
+        if ( 0 === $user_id ) {
+            wp_send_json_error( [ 'message' => __( 'Please login', 'wpam' ) ] );
+        }
+
         $start = get_post_meta( $auction_id, '_auction_start', true );
         $end   = get_post_meta( $auction_id, '_auction_end', true );
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,6 +3,9 @@ $_tests_dir = getenv( 'WP_TESTS_DIR' );
 if ( ! $_tests_dir ) {
     $_tests_dir = dirname( __DIR__ ) . '/vendor/wp-phpunit/wp-phpunit';
 }
+if ( ! defined( 'WP_TESTS_CONFIG_FILE_PATH' ) ) {
+    define( 'WP_TESTS_CONFIG_FILE_PATH', __DIR__ . '/wp-tests-config.php' );
+}
 require_once $_tests_dir . '/includes/functions.php';
 if ( ! class_exists( 'WooCommerce' ) ) {
     class WooCommerce {}

--- a/tests/test-bid.php
+++ b/tests/test-bid.php
@@ -17,4 +17,21 @@ class Test_WPAM_Bid extends WP_Ajax_UnitTestCase {
         }
         $this->fail( 'Expected AJAX die.' );
     }
+
+    public function test_place_bid_requires_login() {
+        $_POST = [
+            'nonce'      => wp_create_nonce( 'wpam_place_bid' ),
+            'auction_id' => 1,
+            'bid'        => 1,
+        ];
+        try {
+            $this->_handleAjax( 'wpam_place_bid' );
+        } catch ( WPAjaxDieContinueException $e ) {
+            $response = json_decode( $this->_last_response, true );
+            $this->assertFalse( $response['success'] );
+            $this->assertSame( 'Please login', $response['data']['message'] );
+            return;
+        }
+        $this->fail( 'Expected AJAX die.' );
+    }
 }


### PR DESCRIPTION
## Summary
- require login before placing a bid
- configure bootstrap for WP test config
- test unauthenticated bid attempt

## Testing
- `composer update --no-interaction`
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_6888f012987883338907dc52f292ee73