### PR TITLE
Align realtime settings to single provider option

### DIFF
--- a/admin/class-wpam-admin.php
+++ b/admin/class-wpam-admin.php
@@ -56,13 +56,11 @@ class WPAM_Admin {
         register_setting( 'wpam_settings', 'wpam_default_increment' );
         register_setting( 'wpam_settings', 'wpam_soft_close' );
         register_setting( 'wpam_settings', 'wpam_enable_twilio' );
-        register_setting( 'wpam_settings', 'wpam_enable_pusher' );
         register_setting( 'wpam_settings', 'wpam_enable_firebase' );
         register_setting( 'wpam_settings', 'wpam_twilio_sid' );
         register_setting( 'wpam_settings', 'wpam_twilio_token' );
         register_setting( 'wpam_settings', 'wpam_twilio_from' );
 
-        register_setting( 'wpam_settings', 'wpam_pusher_enabled' );
         register_setting( 'wpam_settings', 'wpam_pusher_app_id' );
         register_setting( 'wpam_settings', 'wpam_pusher_key' );
         register_setting( 'wpam_settings', 'wpam_pusher_secret' );
@@ -70,10 +68,6 @@ class WPAM_Admin {
         register_setting( 'wpam_settings', 'wpam_soft_close_threshold' );
         register_setting( 'wpam_settings', 'wpam_soft_close_extend' );
         register_setting( 'wpam_settings', 'wpam_realtime_provider' );
-        register_setting( 'wpam_settings', 'wpam_pusher_app_id' );
-        register_setting( 'wpam_settings', 'wpam_pusher_key' );
-        register_setting( 'wpam_settings', 'wpam_pusher_secret' );
-        register_setting( 'wpam_settings', 'wpam_pusher_cluster' );
 
         add_settings_section( 'wpam_general', __( 'Auction Defaults', 'wpam' ), '__return_false', 'wpam_settings' );
         add_settings_section( 'wpam_providers', __( 'Providers', 'wpam' ), '__return_false', 'wpam_settings' );      
@@ -122,13 +116,6 @@ class WPAM_Admin {
             'wpam_providers'
         );
 
-        add_settings_field(
-            'wpam_enable_pusher',
-            __( 'Enable Pusher', 'wpam' ),
-            [ $this, 'field_enable_pusher' ],
-            'wpam_settings',
-            'wpam_providers'
-        );
 
         add_settings_field(
             'wpam_enable_firebase',
@@ -219,11 +206,6 @@ class WPAM_Admin {
     }
 
 
-    public function field_pusher_enabled() {
-        $value = get_option( 'wpam_pusher_enabled', false );
-        echo '<input type="checkbox" name="wpam_pusher_enabled" value="1"' . checked( 1, $value, false ) . ' /> ' . esc_html__( 'Enable real-time updates via Pusher', 'wpam' );
-    }
-
     public function field_pusher_app_id() {
         $value = esc_attr( get_option( 'wpam_pusher_app_id', '' ) );
         echo '<input type="text" class="regular-text" name="wpam_pusher_app_id" value="' . $value . '" />';
@@ -264,11 +246,6 @@ class WPAM_Admin {
         echo '<input type="checkbox" name="wpam_enable_twilio" value="1"' . checked( 1, $value, false ) . ' />';
     }
 
-    public function field_enable_pusher() {
-        $value = get_option( 'wpam_enable_pusher', false );
-        echo '<input type="checkbox" name="wpam_enable_pusher" value="1"' . checked( 1, $value, false ) . ' />';
-    }
-
     public function field_enable_firebase() {
         $value = get_option( 'wpam_enable_firebase', false );
         echo '<input type="checkbox" name="wpam_enable_firebase" value="1"' . checked( 1, $value, false ) . ' />';
@@ -280,26 +257,6 @@ class WPAM_Admin {
         echo '<option value="none"' . selected( $value, 'none', false ) . '>' . esc_html__( 'None', 'wpam' ) . '</option>';
         echo '<option value="pusher"' . selected( $value, 'pusher', false ) . '>' . esc_html__( 'Pusher', 'wpam' ) . '</option>';
         echo '</select>';
-    }
-
-    public function field_pusher_app_id() {
-        $value = esc_attr( get_option( 'wpam_pusher_app_id', '' ) );
-        echo '<input type="text" class="regular-text" name="wpam_pusher_app_id" value="' . $value . '" />';
-    }
-
-    public function field_pusher_key() {
-        $value = esc_attr( get_option( 'wpam_pusher_key', '' ) );
-        echo '<input type="text" class="regular-text" name="wpam_pusher_key" value="' . $value . '" />';
-    }
-
-    public function field_pusher_secret() {
-        $value = esc_attr( get_option( 'wpam_pusher_secret', '' ) );
-        echo '<input type="text" class="regular-text" name="wpam_pusher_secret" value="' . $value . '" />';
-    }
-
-    public function field_pusher_cluster() {
-        $value = esc_attr( get_option( 'wpam_pusher_cluster', '' ) );
-        echo '<input type="text" class="regular-text" name="wpam_pusher_cluster" value="' . $value . '" />';
     }
 
     public function render_auctions_page() {

--- a/includes/api-integrations/class-pusher-provider.php
+++ b/includes/api-integrations/class-pusher-provider.php
@@ -9,13 +9,13 @@ class WPAM_Pusher_Provider implements WPAM_Realtime_Provider {
     protected $channel = 'wpam-auctions';
 
     public function __construct() {
-        $enabled = get_option( 'wpam_pusher_enabled' );
-        $app_id  = get_option( 'wpam_pusher_app_id' );
-        $key     = get_option( 'wpam_pusher_key' );
-        $secret  = get_option( 'wpam_pusher_secret' );
-        $cluster = get_option( 'wpam_pusher_cluster' );
+        $provider = get_option( 'wpam_realtime_provider', 'none' );
+        $app_id   = get_option( 'wpam_pusher_app_id' );
+        $key      = get_option( 'wpam_pusher_key' );
+        $secret   = get_option( 'wpam_pusher_secret' );
+        $cluster  = get_option( 'wpam_pusher_cluster' );
 
-        if ( $enabled && $app_id && $key && $secret && $cluster ) {
+        if ( 'pusher' === $provider && $app_id && $key && $secret && $cluster ) {
             $this->pusher = new Pusher(
                 $key,
                 $secret,

--- a/public/class-wpam-public.php
+++ b/public/class-wpam-public.php
@@ -5,7 +5,9 @@ class WPAM_Public {
     }
 
     public function enqueue_scripts() {
-        $pusher_enabled = get_option( 'wpam_pusher_enabled' );
+        $provider       = get_option( 'wpam_realtime_provider', 'none' );
+        $pusher_enabled = ( 'pusher' === $provider );
+
         if ( $pusher_enabled ) {
             wp_enqueue_script( 'pusher-js', 'https://js.pusher.com/7.2/pusher.min.js', [], '7.2', true );
         }
@@ -19,7 +21,7 @@ class WPAM_Public {
                 'bid_nonce'       => wp_create_nonce( 'wpam_place_bid' ),
                 'watchlist_nonce' => wp_create_nonce( 'wpam_toggle_watchlist' ),
                 'highest_nonce'   => wp_create_nonce( 'wpam_get_highest_bid' ),
-                'pusher_enabled'  => (bool) $pusher_enabled,
+                'pusher_enabled'  => $pusher_enabled,
                 'pusher_key'      => get_option( 'wpam_pusher_key' ),
                 'pusher_cluster'  => get_option( 'wpam_pusher_cluster' ),
                 'pusher_channel'  => 'wpam-auctions',


### PR DESCRIPTION
## Summary
- consolidate realtime provider logic under a single option `wpam_realtime_provider`
- remove unused `wpam_pusher_enabled` logic
- update admin UI to select provider without extra enable checkbox
- apply provider check to frontend script registration and Pusher class

## Testing
- `php -l includes/api-integrations/class-pusher-provider.php`
- `php -l public/class-wpam-public.php`
- `php -l admin/class-wpam-admin.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `vendor/bin/phpcs` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6889003edc748333ba51bebfb6b4a4b6