### PR TITLE
Add auction status and watchlist tests

### DIFF
--- a/tests/test-bid.php
+++ b/tests/test-bid.php
@@ -34,4 +34,58 @@ class Test_WPAM_Bid extends WP_Ajax_UnitTestCase {
         }
         $this->fail( 'Expected AJAX die.' );
     }
+
+    public function test_place_bid_before_start() {
+        $auction_id  = $this->factory->post->create([
+            'post_type' => 'product',
+        ]);
+        update_post_meta( $auction_id, '_auction_start', date( 'Y-m-d H:i:s', time() + 3600 ) );
+        update_post_meta( $auction_id, '_auction_end', date( 'Y-m-d H:i:s', time() + 7200 ) );
+
+        $user_id = $this->factory->user->create();
+        wp_set_current_user( $user_id );
+
+        $_POST = [
+            'nonce'      => wp_create_nonce( 'wpam_place_bid' ),
+            'auction_id' => $auction_id,
+            'bid'        => 10,
+        ];
+
+        try {
+            $this->_handleAjax( 'wpam_place_bid' );
+        } catch ( WPAjaxDieContinueException $e ) {
+            $response = json_decode( $this->_last_response, true );
+            $this->assertFalse( $response['success'] );
+            $this->assertSame( 'Auction not active', $response['data']['message'] );
+            return;
+        }
+        $this->fail( 'Expected AJAX die.' );
+    }
+
+    public function test_place_bid_after_end() {
+        $auction_id  = $this->factory->post->create([
+            'post_type' => 'product',
+        ]);
+        update_post_meta( $auction_id, '_auction_start', date( 'Y-m-d H:i:s', time() - 7200 ) );
+        update_post_meta( $auction_id, '_auction_end', date( 'Y-m-d H:i:s', time() - 3600 ) );
+
+        $user_id = $this->factory->user->create();
+        wp_set_current_user( $user_id );
+
+        $_POST = [
+            'nonce'      => wp_create_nonce( 'wpam_place_bid' ),
+            'auction_id' => $auction_id,
+            'bid'        => 10,
+        ];
+
+        try {
+            $this->_handleAjax( 'wpam_place_bid' );
+        } catch ( WPAjaxDieContinueException $e ) {
+            $response = json_decode( $this->_last_response, true );
+            $this->assertFalse( $response['success'] );
+            $this->assertSame( 'Auction not active', $response['data']['message'] );
+            return;
+        }
+        $this->fail( 'Expected AJAX die.' );
+    }
 }

--- a/tests/test-watchlist.php
+++ b/tests/test-watchlist.php
@@ -33,4 +33,39 @@ class Test_WPAM_Watchlist extends WP_Ajax_UnitTestCase {
         $this->assertTrue( $second['success'] );
         $this->assertSame( 'Removed from watchlist', $second['data']['message'] );
     }
+
+    public function test_get_watchlist_requires_login() {
+        wp_set_current_user( 0 );
+        try {
+            $this->_handleAjax( 'wpam_get_watchlist' );
+        } catch ( WPAjaxDieContinueException $e ) {
+            $response = json_decode( $this->_last_response, true );
+            $this->assertFalse( $response['success'] );
+            $this->assertSame( 'Please login', $response['data']['message'] );
+            return;
+        }
+        $this->fail( 'Expected AJAX die.' );
+    }
+
+    public function test_get_watchlist_returns_items() {
+        $_POST = [
+            'nonce'      => wp_create_nonce( 'wpam_toggle_watchlist' ),
+            'auction_id' => $this->auction_id,
+        ];
+        try {
+            $this->_handleAjax( 'wpam_toggle_watchlist' );
+        } catch ( WPAjaxDieContinueException $e ) {
+            // Ignore result
+        }
+
+        try {
+            $this->_handleAjax( 'wpam_get_watchlist' );
+        } catch ( WPAjaxDieContinueException $e ) {
+            $response = json_decode( $this->_last_response, true );
+        }
+
+        $this->assertTrue( $response['success'] );
+        $this->assertCount( 1, $response['data']['items'] );
+        $this->assertSame( $this->auction_id, $response['data']['items'][0]['id'] );
+    }
 }


### PR DESCRIPTION
## Summary
- ensure bidding fails when auction isn't active
- test watchlist retrieval for logged in and logged out users

## Testing
- `composer install`
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Error establishing DB connection)*

------
https://chatgpt.com/codex/tasks/task_e_6889038e7c48833394e0f6b367d8d152