### PR TITLE
Add auction status and watchlist tests

### DIFF
--- a/tests/test-bid-status.php
+++ b/tests/test-bid-status.php
@@ -1,0 +1,55 @@
+<?php
+class Test_WPAM_Bid_Status extends WP_Ajax_UnitTestCase {
+    public function set_up() : void {
+        parent::set_up();
+        new WPAM_Bid();
+    }
+
+    public function test_bid_fails_not_started() {
+        $auction_id = $this->factory->post->create([
+            'post_type' => 'product',
+        ]);
+        update_post_meta( $auction_id, '_auction_start', date( 'Y-m-d H:i:s', time() + 3600 ) );
+        update_post_meta( $auction_id, '_auction_end', date( 'Y-m-d H:i:s', time() + 7200 ) );
+        $user_id = $this->factory->user->create();
+        wp_set_current_user( $user_id );
+        $_POST = [
+            'nonce'      => wp_create_nonce( 'wpam_place_bid' ),
+            'auction_id' => $auction_id,
+            'bid'        => 5,
+        ];
+        try {
+            $this->_handleAjax( 'wpam_place_bid' );
+        } catch ( WPAjaxDieContinueException $e ) {
+            $response = json_decode( $this->_last_response, true );
+            $this->assertFalse( $response['success'] );
+            $this->assertSame( 'Auction not active', $response['data']['message'] );
+            return;
+        }
+        $this->fail( 'Expected AJAX die.' );
+    }
+
+    public function test_bid_fails_expired() {
+        $auction_id = $this->factory->post->create([
+            'post_type' => 'product',
+        ]);
+        update_post_meta( $auction_id, '_auction_start', date( 'Y-m-d H:i:s', time() - 7200 ) );
+        update_post_meta( $auction_id, '_auction_end', date( 'Y-m-d H:i:s', time() - 3600 ) );
+        $user_id = $this->factory->user->create();
+        wp_set_current_user( $user_id );
+        $_POST = [
+            'nonce'      => wp_create_nonce( 'wpam_place_bid' ),
+            'auction_id' => $auction_id,
+            'bid'        => 5,
+        ];
+        try {
+            $this->_handleAjax( 'wpam_place_bid' );
+        } catch ( WPAjaxDieContinueException $e ) {
+            $response = json_decode( $this->_last_response, true );
+            $this->assertFalse( $response['success'] );
+            $this->assertSame( 'Auction not active', $response['data']['message'] );
+            return;
+        }
+        $this->fail( 'Expected AJAX die.' );
+    }
+}

--- a/tests/test-watchlist-auth.php
+++ b/tests/test-watchlist-auth.php
@@ -1,0 +1,46 @@
+<?php
+class Test_WPAM_Watchlist_Auth extends WP_Ajax_UnitTestCase {
+    protected $auction_id;
+    public function set_up() : void {
+        parent::set_up();
+        new WPAM_Watchlist();
+        WPAM_Install::activate();
+        $this->auction_id = $this->factory->post->create([
+            'post_type' => 'product',
+        ]);
+    }
+
+    public function test_get_watchlist_error_if_logged_out() {
+        wp_set_current_user( 0 );
+        try {
+            $this->_handleAjax( 'wpam_get_watchlist' );
+        } catch ( WPAjaxDieContinueException $e ) {
+            $response = json_decode( $this->_last_response, true );
+            $this->assertFalse( $response['success'] );
+            $this->assertSame( 'Please login', $response['data']['message'] );
+            return;
+        }
+        $this->fail( 'Expected AJAX die.' );
+    }
+
+    public function test_get_watchlist_success_for_user() {
+        $user_id = $this->factory->user->create();
+        wp_set_current_user( $user_id );
+        // Add item to watchlist first
+        $_POST = [
+            'nonce'      => wp_create_nonce( 'wpam_toggle_watchlist' ),
+            'auction_id' => $this->auction_id,
+        ];
+        try {
+            $this->_handleAjax( 'wpam_toggle_watchlist' );
+        } catch ( WPAjaxDieContinueException $e ) {}
+        try {
+            $this->_handleAjax( 'wpam_get_watchlist' );
+        } catch ( WPAjaxDieContinueException $e ) {
+            $response = json_decode( $this->_last_response, true );
+        }
+        $this->assertTrue( $response['success'] );
+        $this->assertCount( 1, $response['data']['items'] );
+        $this->assertSame( $this->auction_id, $response['data']['items'][0]['id'] );
+    }
+}


### PR DESCRIPTION
## Summary
- add tests covering bidding while auction inactive
- add tests for watchlist access control

## Testing
- `php phpunit.phar --bootstrap tests/bootstrap.php tests` *(fails: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_6889067382188333979365ec914a20c3