### PR TITLE
Fix provider loading order

### DIFF
--- a/includes/class-wpam-loader.php
+++ b/includes/class-wpam-loader.php
@@ -10,6 +10,7 @@ class WPAM_Loader {
         require_once WPAM_PLUGIN_DIR . 'includes/class-wpam-watchlist.php';
         require_once WPAM_PLUGIN_DIR . 'includes/class-wpam-messages.php';
         require_once WPAM_PLUGIN_DIR . 'includes/class-wpam-notifications.php';
+        require_once WPAM_PLUGIN_DIR . 'includes/api-integrations/class-api-provider.php';
         require_once WPAM_PLUGIN_DIR . 'includes/api-integrations/class-twilio-provider.php';
         require_once WPAM_PLUGIN_DIR . 'admin/class-wpam-admin.php';
         require_once WPAM_PLUGIN_DIR . 'public/class-wpam-public.php';


### PR DESCRIPTION
## Summary
- load the WPAM API interface before Twilio provider

## Testing
- `vendor/bin/phpunit` *(fails: shows usage output)*
- `vendor/bin/phpcs -d memory_limit=1G --ignore=vendor/* includes` *(fails: reports coding standard violations)*

------
https://chatgpt.com/codex/tasks/task_e_68890a8383d08333b095b9e89e7b3eed