### PR TITLE
Reschedule auction end cron on soft close

### DIFF
--- a/includes/class-wpam-bid.php
+++ b/includes/class-wpam-bid.php
@@ -84,6 +84,8 @@ class WPAM_Bid {
         if ( $threshold > 0 && $end_ts - $now <= $threshold ) {
             $new_end_ts = $end_ts + $extension;
             update_post_meta( $auction_id, '_auction_end', date( 'Y-m-d H:i:s', $new_end_ts ) );
+            wp_clear_scheduled_hook( 'wpam_auction_end', [ $auction_id ] );
+            wp_schedule_single_event( $new_end_ts, 'wpam_auction_end', [ $auction_id ] );
             $extended = true;
         }
 


### PR DESCRIPTION
## Summary
- adjust the cron schedule when a soft-close extends an auction

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `vendor/bin/phpcs -v` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68890cd89bd08333be2ef13ad602fb2c