### PR TITLE
Secure ajax endpoints for message/watchlist

### DIFF
--- a/includes/class-wpam-messages.php
+++ b/includes/class-wpam-messages.php
@@ -39,6 +39,7 @@ class WPAM_Messages {
     }
 
     public function get_messages() {
+        check_ajax_referer( 'wpam_get_messages', 'nonce' );
         if ( empty( $_POST['auction_id'] ) ) {
             wp_send_json_error( [ 'message' => __( 'Invalid auction', 'wpam' ) ] );
         }

--- a/includes/class-wpam-watchlist.php
+++ b/includes/class-wpam-watchlist.php
@@ -57,6 +57,7 @@ class WPAM_Watchlist {
     }
 
     public function get_watchlist() {
+        check_ajax_referer( 'wpam_get_watchlist', 'nonce' );
         $user_id = get_current_user_id();
         if ( ! $user_id ) {
             wp_send_json_error( [ 'message' => __( 'Please login', 'wpam' ) ] );

--- a/public/class-wpam-public.php
+++ b/public/class-wpam-public.php
@@ -20,6 +20,7 @@ class WPAM_Public {
                 'ajax_url'        => admin_url( 'admin-ajax.php' ),
                 'bid_nonce'       => wp_create_nonce( 'wpam_place_bid' ),
                 'watchlist_nonce' => wp_create_nonce( 'wpam_toggle_watchlist' ),
+                'watchlist_get_nonce' => wp_create_nonce( 'wpam_get_watchlist' ),
                 'highest_nonce'   => wp_create_nonce( 'wpam_get_highest_bid' ),
                 'pusher_enabled'  => $pusher_enabled,
                 'pusher_key'      => get_option( 'wpam_pusher_key' ),
@@ -35,6 +36,7 @@ class WPAM_Public {
             [
                 'ajax_url'      => admin_url( 'admin-ajax.php' ),
                 'message_nonce' => wp_create_nonce( 'wpam_submit_question' ),
+                'get_messages_nonce' => wp_create_nonce( 'wpam_get_messages' ),
             ]
         );
     }

--- a/public/js/ajax-messages.js
+++ b/public/js/ajax-messages.js
@@ -4,7 +4,8 @@ jQuery(function($){
             wpam_messages.ajax_url,
             {
                 action: 'wpam_get_messages',
-                auction_id: auctionId
+                auction_id: auctionId,
+                nonce: wpam_messages.get_messages_nonce
             },
             function(res){
                 if(res.success){

--- a/tests/test-watchlist-auth.php
+++ b/tests/test-watchlist-auth.php
@@ -12,6 +12,7 @@ class Test_WPAM_Watchlist_Auth extends WP_Ajax_UnitTestCase {
 
     public function test_get_watchlist_error_if_logged_out() {
         wp_set_current_user( 0 );
+        $_POST = [ 'nonce' => wp_create_nonce( 'wpam_get_watchlist' ) ];
         try {
             $this->_handleAjax( 'wpam_get_watchlist' );
         } catch ( WPAjaxDieContinueException $e ) {
@@ -34,6 +35,7 @@ class Test_WPAM_Watchlist_Auth extends WP_Ajax_UnitTestCase {
         try {
             $this->_handleAjax( 'wpam_toggle_watchlist' );
         } catch ( WPAjaxDieContinueException $e ) {}
+        $_POST = [ 'nonce' => wp_create_nonce( 'wpam_get_watchlist' ) ];
         try {
             $this->_handleAjax( 'wpam_get_watchlist' );
         } catch ( WPAjaxDieContinueException $e ) {

--- a/tests/test-watchlist.php
+++ b/tests/test-watchlist.php
@@ -36,6 +36,7 @@ class Test_WPAM_Watchlist extends WP_Ajax_UnitTestCase {
 
     public function test_get_watchlist_requires_login() {
         wp_set_current_user( 0 );
+        $_POST = [ 'nonce' => wp_create_nonce( 'wpam_get_watchlist' ) ];
         try {
             $this->_handleAjax( 'wpam_get_watchlist' );
         } catch ( WPAjaxDieContinueException $e ) {
@@ -58,6 +59,7 @@ class Test_WPAM_Watchlist extends WP_Ajax_UnitTestCase {
             // Ignore result
         }
 
+        $_POST = [ 'nonce' => wp_create_nonce( 'wpam_get_watchlist' ) ];
         try {
             $this->_handleAjax( 'wpam_get_watchlist' );
         } catch ( WPAjaxDieContinueException $e ) {


### PR DESCRIPTION
## Summary
- validate nonces for retrieving messages and watchlists
- expose new nonces to public scripts
- send nonce when loading auction messages
- update unit tests for nonce requirement

## Testing
- `composer install` *(fails: composer.lock invalid)*
- `composer install --no-dev` *(fails: composer.lock invalid)*
- `vendor/bin/phpunit` *(fails: command not found)*
- `vendor/bin/phpcs -i` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889114681788333b947e3e348fe2786