### PR TITLE
Add Firebase support and soft-close fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ When editing an auction product you can configure additional options in the **Au
 ### Soft-close settings
 
 Under **Auctions → Settings** you can configure the soft-close threshold and the extension duration. If a bid arrives within the threshold, the end time is extended by the duration. By default both values are 30 seconds.
+The older `Soft Close Duration` option is still honored when the new values are empty; it sets both the threshold and the extension length in seconds.
 
 ## Folder structure
 
@@ -61,6 +62,7 @@ Future versions may swap to WebSocket providers found under `includes/api-integr
 
 Under **Auctions → Settings → Realtime Integration** you can select `None` or `Pusher` as the provider. Enter your Pusher app credentials to enable realtime WebSocket updates.
 Twilio SMS notifications can be toggled via the `Enable Twilio Notifications` option (`wpam_enable_twilio`).
+Firebase push notifications are available through the `Enable Firebase` option (`wpam_enable_firebase`) once you provide a valid server key.
 
 ## Running unit tests
 

--- a/admin/class-wpam-admin.php
+++ b/admin/class-wpam-admin.php
@@ -57,6 +57,7 @@ class WPAM_Admin {
         register_setting( 'wpam_settings', 'wpam_soft_close' );
         register_setting( 'wpam_settings', 'wpam_enable_twilio' );
         register_setting( 'wpam_settings', 'wpam_enable_firebase' );
+        register_setting( 'wpam_settings', 'wpam_firebase_server_key' );
         register_setting( 'wpam_settings', 'wpam_twilio_sid' );
         register_setting( 'wpam_settings', 'wpam_twilio_token' );
         register_setting( 'wpam_settings', 'wpam_twilio_from' );
@@ -72,6 +73,7 @@ class WPAM_Admin {
         add_settings_section( 'wpam_general', __( 'Auction Defaults', 'wpam' ), '__return_false', 'wpam_settings' );
         add_settings_section( 'wpam_providers', __( 'Providers', 'wpam' ), '__return_false', 'wpam_settings' );      
         add_settings_section( 'wpam_twilio', __( 'Twilio Integration', 'wpam' ), '__return_false', 'wpam_settings' );
+        add_settings_section( 'wpam_firebase', __( 'Firebase Integration', 'wpam' ), '__return_false', 'wpam_settings' );
         add_settings_section( 'wpam_realtime', __( 'Realtime Integration', 'wpam' ), '__return_false', 'wpam_settings' );
 
         add_settings_section( 'wpam_pusher', __( 'Pusher Realtime', 'wpam' ), '__return_false', 'wpam_settings' );
@@ -123,6 +125,14 @@ class WPAM_Admin {
             [ $this, 'field_enable_firebase' ],
             'wpam_settings',
             'wpam_providers'
+        );
+
+        add_settings_field(
+            'wpam_firebase_server_key',
+            __( 'Firebase Server Key', 'wpam' ),
+            [ $this, 'field_firebase_server_key' ],
+            'wpam_settings',
+            'wpam_firebase'
         );
 
         add_settings_field(
@@ -249,6 +259,11 @@ class WPAM_Admin {
     public function field_enable_firebase() {
         $value = get_option( 'wpam_enable_firebase', false );
         echo '<input type="checkbox" name="wpam_enable_firebase" value="1"' . checked( 1, $value, false ) . ' />';
+    }
+
+    public function field_firebase_server_key() {
+        $value = esc_attr( get_option( 'wpam_firebase_server_key', '' ) );
+        echo '<input type="text" class="regular-text" name="wpam_firebase_server_key" value="' . $value . '" />';
     }
 
     public function field_realtime_provider() {

--- a/includes/api-integrations/class-firebase-provider.php
+++ b/includes/api-integrations/class-firebase-provider.php
@@ -1,0 +1,44 @@
+<?php
+class WPAM_Firebase_Provider implements WPAM_API_Provider {
+    /**
+     * Send a push notification via Firebase Cloud Messaging.
+     *
+     * @param string $token   Device token to send to.
+     * @param string $message Notification message.
+     * @return true|WP_Error
+     */
+    public function send( $token, $message ) {
+        $key = get_option( 'wpam_firebase_server_key' );
+        if ( ! $key || ! $token ) {
+            return new WP_Error( 'firebase_credentials', __( 'Firebase not configured', 'wpam' ) );
+        }
+
+        $body = [
+            'to'   => $token,
+            'notification' => [
+                'title' => __( 'Auction Update', 'wpam' ),
+                'body'  => $message,
+            ],
+        ];
+
+        $response = wp_remote_post( 'https://fcm.googleapis.com/fcm/send', [
+            'body'    => wp_json_encode( $body ),
+            'headers' => [
+                'Authorization' => 'key=' . $key,
+                'Content-Type'  => 'application/json',
+            ],
+            'timeout' => 15,
+        ] );
+
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+
+        $code = wp_remote_retrieve_response_code( $response );
+        if ( $code >= 200 && $code < 300 ) {
+            return true;
+        }
+
+        return new WP_Error( 'firebase_http', wp_remote_retrieve_body( $response ) );
+    }
+}

--- a/includes/class-wpam-bid.php
+++ b/includes/class-wpam-bid.php
@@ -78,8 +78,17 @@ class WPAM_Bid {
         // Extend auction end time if within soft close window
         $extended   = false;
         $new_end_ts = $end_ts;
-        $threshold  = absint( get_option( 'wpam_soft_close_threshold', 30 ) );
-        $extension  = absint( get_option( 'wpam_soft_close_extend', 30 ) );
+        $threshold  = absint( get_option( 'wpam_soft_close_threshold', 0 ) );
+        $extension  = absint( get_option( 'wpam_soft_close_extend', 0 ) );
+        $legacy     = absint( get_option( 'wpam_soft_close', 0 ) ) * 60;
+
+        if ( 0 === $threshold ) {
+            $threshold = $legacy;
+        }
+
+        if ( 0 === $extension ) {
+            $extension = $legacy;
+        }
 
         if ( $threshold > 0 && $end_ts - $now <= $threshold ) {
             $new_end_ts = $end_ts + $extension;

--- a/includes/class-wpam-notifications.php
+++ b/includes/class-wpam-notifications.php
@@ -2,18 +2,27 @@
 class WPAM_Notifications {
     public static function send_to_user( $user_id, $subject, $message ) {
         $sms_enabled   = get_option( 'wpam_enable_twilio', '0' );
+        $push_enabled  = get_option( 'wpam_enable_firebase', '0' );
 
         $user  = get_user_by( 'id', $user_id );
         if ( ! $user ) {
             return;
         }
 
-        $phone = get_user_meta( $user_id, 'billing_phone', true );
-        $provider = new WPAM_Twilio_Provider();
+        $phone   = get_user_meta( $user_id, 'billing_phone', true );
+        $token   = get_user_meta( $user_id, 'wpam_firebase_token', true );
+
+        $sms_provider  = new WPAM_Twilio_Provider();
+        $push_provider = new WPAM_Firebase_Provider();
 
         $sent = false;
-        if ( $sms_enabled && $phone ) {
-            $result = $provider->send( $phone, $message );
+        if ( $push_enabled && $token ) {
+            $result = $push_provider->send( $token, $message );
+            $sent   = ! is_wp_error( $result );
+        }
+
+        if ( ! $sent && $sms_enabled && $phone ) {
+            $result = $sms_provider->send( $phone, $message );
             $sent   = ! is_wp_error( $result );
         }
 

--- a/languages/wp-auction-manager.pot
+++ b/languages/wp-auction-manager.pot
@@ -33,3 +33,11 @@ msgstr ""
 #: wp-auction-manager.php
 msgid "https://muzammil.dev"
 msgstr ""
+
+#: admin/class-wpam-admin.php
+msgid "Enable Firebase"
+msgstr ""
+
+#: admin/class-wpam-admin.php
+msgid "Firebase Server Key"
+msgstr ""


### PR DESCRIPTION
## Summary
- implement Firebase provider for push notifications
- send notifications using Firebase token if enabled
- fallback to legacy `wpam_soft_close` setting if threshold/extend values are empty
- expose Firebase settings in admin
- document Firebase option and clarify soft close behaviour
- update translation template

## Testing
- `vendor/bin/phpunit` *(fails: Class "PHPUnit\TextUI\Command" not found)*
- `vendor/bin/phpcs -d memory_limit=512M admin includes public templates` *(fails: multiple coding standard errors)*

------
https://chatgpt.com/codex/tasks/task_e_688912b57e708333b68f52fd68d54d79