### PR TITLE
Add React-based frontend shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Under **Auctions → Settings → Realtime Integration** you can select `None` o
 Twilio SMS notifications can be toggled via the `Enable Twilio Notifications` option (`wpam_enable_twilio`).
 Firebase push notifications are available through the `Enable Firebase` option (`wpam_enable_firebase`) once you provide a valid server key.
 
+### React frontend
+
+The plugin includes a lightweight React application that can render either a list of auctions or a single auction view. Use the `[wpam_auction_app]` shortcode on any page to load the React interface. When used on a single auction product page the current auction is automatically displayed.
+
 ## Running unit tests
 
 A `tests/` directory will contain PHPUnit tests in the future. Once available, install development dependencies and execute:

--- a/public/js/react/auction-app.js
+++ b/public/js/react/auction-app.js
@@ -1,0 +1,57 @@
+(function( wp ) {
+    const { createElement, useEffect, useState } = wp.element;
+    const apiFetch = wp.apiFetch;
+
+    function AuctionList() {
+        const [ auctions, setAuctions ] = useState( [] );
+
+        useEffect( () => {
+            apiFetch( { path: '/wp-json/wp/v2/product?per_page=10' } ).then( setAuctions );
+        }, [] );
+
+        return createElement(
+            'div',
+            { className: 'wpam-auction-list' },
+            auctions.map( ( auction ) =>
+                createElement(
+                    'div',
+                    { key: auction.id },
+                    createElement( 'a', { href: auction.link }, auction.title.rendered )
+                )
+            )
+        );
+    }
+
+    function SingleAuction( { auctionId } ) {
+        const [ auction, setAuction ] = useState( null );
+
+        useEffect( () => {
+            if ( ! auctionId ) return;
+            apiFetch( { path: '/wp-json/wp/v2/product/' + auctionId } ).then( setAuction );
+        }, [ auctionId ] );
+
+        if ( ! auction ) {
+            return createElement( 'div', null, 'Loading...' );
+        }
+
+        return createElement(
+            'div',
+            { className: 'wpam-auction-single' },
+            createElement( 'h2', null, auction.title.rendered )
+        );
+    }
+
+    function App() {
+        const auctionId = parseInt( window.wpamReactPage.auction_id, 10 );
+        return auctionId
+            ? createElement( SingleAuction, { auctionId } )
+            : createElement( AuctionList, null );
+    }
+
+    document.addEventListener( 'DOMContentLoaded', function() {
+        const root = document.getElementById( 'wpam-react-root' );
+        if ( root ) {
+            wp.element.render( createElement( App, null ), root );
+        }
+    } );
+})( window.wp );


### PR DESCRIPTION
## Summary
- create React components in `public/js/react/auction-app.js`
- enqueue script with `wp-element` and `wp-api-fetch` dependencies and expose config
- add `[wpam_auction_app]` shortcode
- document the new React frontend in README

## Testing
- `composer install` *(fails: composer.lock invalid)*
- `vendor/bin/phpunit` *(fails: no such file)*
- `vendor/bin/phpcs` *(fails: no such file)*

------
https://chatgpt.com/codex/tasks/task_e_6889146772888333b365a0f49fa54893