### PR TITLE
Add default increment field

### DIFF
--- a/admin/class-wpam-admin.php
+++ b/admin/class-wpam-admin.php
@@ -246,6 +246,11 @@ class WPAM_Admin {
         echo '<input type="number" class="small-text" name="wpam_soft_close_extend" value="' . $value . '" />';
     }
 
+    public function field_default_increment() {
+        $value = esc_attr( get_option( 'wpam_default_increment', 1 ) );
+        echo '<input type="number" step="0.01" class="small-text" name="wpam_default_increment" value="' . $value . '" />';
+    }
+
     public function field_soft_close() {
         $value = esc_attr( get_option( 'wpam_soft_close', 0 ) );
         echo '<input type="number" class="small-text" name="wpam_soft_close" value="' . $value . '" />';


### PR DESCRIPTION
## Summary
- add missing `field_default_increment` method to admin

## Testing
- `php -l admin/class-wpam-admin.php`
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_688918e114bc8333b427c838c97d72bb