### PR TITLE
Add basic frontend styles

### DIFF
--- a/public/class-wpam-public.php
+++ b/public/class-wpam-public.php
@@ -52,6 +52,8 @@ class WPAM_Public {
             wp_enqueue_script( 'pusher-js', 'https://js.pusher.com/7.2/pusher.min.js', [], '7.2', true );
         }
 
+        wp_enqueue_style( 'wpam-frontend', WPAM_PLUGIN_URL . 'public/css/wpam-frontend.css', [ 'woocommerce-general' ], WPAM_PLUGIN_VERSION );
+
         wp_enqueue_script( 'wpam-ajax-bid', WPAM_PLUGIN_URL . 'public/js/ajax-bid.js', [ 'jquery' ], WPAM_PLUGIN_VERSION, true );
         wp_localize_script(
             'wpam-ajax-bid',
@@ -143,7 +145,7 @@ class WPAM_Public {
         $highest = $wpdb->get_var( $wpdb->prepare( "SELECT MAX(bid_amount) FROM {$wpdb->prefix}wc_auction_bids WHERE auction_id = %d", $auction_id ) );
         $highest = $highest ? floatval( $highest ) : 0;
 
-        echo '<p class="wpam-status">' . esc_html( ucfirst( $status ) ) . '</p>';
+        echo '<p class="wpam-status woocommerce-message">' . esc_html( ucfirst( $status ) ) . '</p>';
         echo '<p class="wpam-type">' . esc_html( ucfirst( $type ) ) . '</p>';
         echo '<p class="wpam-countdown" data-end="' . esc_attr( $end_ts ) . '"></p>';
         echo '<p>' . esc_html__( 'Current Bid:', 'wpam' ) . ' <span class="wpam-current-bid" data-auction-id="' . esc_attr( $auction_id ) . '">' . esc_html( $highest ) . '</span></p>';
@@ -154,14 +156,14 @@ class WPAM_Public {
         echo '<form class="wpam-bid-form">';
         echo '<input type="number" step="0.01" class="wpam-bid-input" />';
         wp_nonce_field( 'wpam_place_bid', 'wpam_bid_nonce', false );
-        echo '<button class="wpam-bid-button" data-auction-id="' . esc_attr( $product->get_id() ) . '">' . esc_html__( 'Place Bid', 'wpam' ) . '</button>';
+        echo '<button class="button wpam-bid-button" data-auction-id="' . esc_attr( $product->get_id() ) . '">' . esc_html__( 'Place Bid', 'wpam' ) . '</button>';
         echo '</form>';
     }
 
     public function render_watchlist_button() {
         global $product;
         wp_nonce_field( 'wpam_toggle_watchlist', 'wpam_watchlist_nonce', false );
-        echo '<button class="wpam-watchlist-button" data-auction-id="' . esc_attr( $product->get_id() ) . '">' . esc_html__( 'Toggle Watchlist', 'wpam' ) . '</button>';
+        echo '<button class="button wpam-watchlist-button" data-auction-id="' . esc_attr( $product->get_id() ) . '">' . esc_html__( 'Toggle Watchlist', 'wpam' ) . '</button>';
     }
 
     public function render_messages() {

--- a/public/css/wpam-frontend.css
+++ b/public/css/wpam-frontend.css
@@ -1,0 +1,38 @@
+.wpam-status {
+    display: inline-block;
+    margin-bottom: 10px;
+    padding: 4px 8px;
+    background: #f0f0f0;
+    border-radius: 3px;
+    font-weight: 600;
+}
+
+.wpam-bid-form {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+.wpam-bid-form input {
+    max-width: 120px;
+}
+
+.wpam-bid-button,
+.wpam-watchlist-button {
+    background: #96588a;
+    color: #fff;
+    border: none;
+    padding: 6px 12px;
+    cursor: pointer;
+    border-radius: 3px;
+}
+
+.wpam-bid-button:hover,
+.wpam-watchlist-button:hover {
+    opacity: 0.9;
+}
+
+.wpam-watchlist-button {
+    margin-top: 5px;
+}

--- a/templates/single-auction.php
+++ b/templates/single-auction.php
@@ -11,12 +11,12 @@ get_header();
     <form class="wpam-bid-form">
         <input type="number" step="0.01" class="wpam-bid-input" />
         <?php wp_nonce_field( 'wpam_place_bid', 'wpam_bid_nonce', false ); ?>
-        <button class="wpam-bid-button" data-auction-id="<?php the_ID(); ?>">
+        <button class="button wpam-bid-button" data-auction-id="<?php the_ID(); ?>">
             <?php _e( 'Place Bid', 'wpam' ); ?>
         </button>
     </form>
     <?php wp_nonce_field( 'wpam_toggle_watchlist', 'wpam_watchlist_nonce', false ); ?>
-    <button class="wpam-watchlist-button" data-auction-id="<?php the_ID(); ?>">
+    <button class="button wpam-watchlist-button" data-auction-id="<?php the_ID(); ?>">
         <?php _e( 'Toggle Watchlist', 'wpam' ); ?>
     </button>
 


### PR DESCRIPTION
## Summary
- style auction components with a new stylesheet
- load the stylesheet and apply WooCommerce button classes

## Testing
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Class "PHPUnit\TextUI\Command" not found)*
- `vendor/bin/phpcs --standard=phpcs.xml -d memory_limit=512M public/class-wpam-public.php templates/single-auction.php` *(errors: coding standards violations)*

------
https://chatgpt.com/codex/tasks/task_e_68892feaba348333abd32eeec7b07352