### PR TITLE
Add namespaces and composer autoloading

### DIFF
--- a/admin/class-wpam-admin.php
+++ b/admin/class-wpam-admin.php
@@ -1,4 +1,6 @@
 <?php
+namespace WPAM\Admin;
+
 class WPAM_Admin {
     public function __construct() {
         add_action( 'admin_menu', [ $this, 'add_menu' ] );
@@ -301,7 +303,6 @@ class WPAM_Admin {
     }
 
     public function render_auctions_page() {
-        require_once WPAM_PLUGIN_DIR . 'admin/class-wpam-auctions-table.php';
         $table = new WPAM_Auctions_Table();
         $table->prepare_items();
         echo '<div class="wrap">';
@@ -314,7 +315,6 @@ class WPAM_Admin {
     }
 
     public function render_bids_page() {
-        require_once WPAM_PLUGIN_DIR . 'admin/class-wpam-bids-table.php';
         $auction_id = isset( $_GET['auction_id'] ) ? absint( $_GET['auction_id'] ) : 0;
         echo '<div class="wrap">';
         if ( ! $auction_id ) {
@@ -334,7 +334,6 @@ class WPAM_Admin {
     }
 
     public function render_messages_page() {
-        require_once WPAM_PLUGIN_DIR . 'admin/class-wpam-messages-table.php';
 
         if ( isset( $_GET['action'], $_GET['message'] ) && in_array( $_GET['action'], [ 'approve', 'unapprove' ], true ) ) {
             $message_id = absint( $_GET['message'] );

--- a/admin/class-wpam-auctions-table.php
+++ b/admin/class-wpam-auctions-table.php
@@ -1,9 +1,11 @@
 <?php
+namespace WPAM\Admin;
+
 if ( ! class_exists( 'WP_List_Table' ) ) {
     require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
 }
 
-class WPAM_Auctions_Table extends WP_List_Table {
+class WPAM_Auctions_Table extends \WP_List_Table {
     public function prepare_items() {
         $status = isset( $_GET['status'] ) ? sanitize_text_field( wp_unslash( $_GET['status'] ) ) : '';
         $args = [

--- a/admin/class-wpam-bids-table.php
+++ b/admin/class-wpam-bids-table.php
@@ -1,9 +1,11 @@
 <?php
+namespace WPAM\Admin;
+
 if ( ! class_exists( 'WP_List_Table' ) ) {
     require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
 }
 
-class WPAM_Bids_Table extends WP_List_Table {
+class WPAM_Bids_Table extends \WP_List_Table {
     protected $auction_id;
 
     public function __construct( $auction_id ) {

--- a/admin/class-wpam-messages-table.php
+++ b/admin/class-wpam-messages-table.php
@@ -1,9 +1,11 @@
 <?php
+namespace WPAM\Admin;
+
 if ( ! class_exists( 'WP_List_Table' ) ) {
     require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
 }
 
-class WPAM_Messages_Table extends WP_List_Table {
+class WPAM_Messages_Table extends \WP_List_Table {
     public function prepare_items() {
         global $wpdb;
         $table   = $wpdb->prefix . 'wc_auction_messages';

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,13 @@
 {
   "name": "wp-auction-manager/wp-auction-manager",
   "type": "project",
+  "autoload": {
+    "psr-4": {
+      "WPAM\\Admin\\": "admin/",
+      "WPAM\\Includes\\": "includes/",
+      "WPAM\\Public\\": "public/"
+    }
+  },
   "require-dev": {
     "phpunit/phpunit": "^9",
     "wp-phpunit/wp-phpunit": "^6",

--- a/includes/api-integrations/class-api-provider.php
+++ b/includes/api-integrations/class-api-provider.php
@@ -1,4 +1,6 @@
 <?php
+namespace WPAM\Includes;
+
 interface WPAM_API_Provider {
     public function send( $to, $message );
 }

--- a/includes/api-integrations/class-firebase-provider.php
+++ b/includes/api-integrations/class-firebase-provider.php
@@ -1,4 +1,6 @@
 <?php
+namespace WPAM\Includes;
+
 class WPAM_Firebase_Provider implements WPAM_API_Provider {
     /**
      * Send a push notification via Firebase Cloud Messaging.

--- a/includes/api-integrations/class-pusher-provider.php
+++ b/includes/api-integrations/class-pusher-provider.php
@@ -1,4 +1,6 @@
 <?php
+namespace WPAM\Includes;
+
 use Pusher\Pusher;
 
 class WPAM_Pusher_Provider implements WPAM_Realtime_Provider {

--- a/includes/api-integrations/class-realtime-provider.php
+++ b/includes/api-integrations/class-realtime-provider.php
@@ -1,4 +1,6 @@
 <?php
+namespace WPAM\Includes;
+
 interface WPAM_Realtime_Provider {
     public function send_bid_update( $auction_id, $bid_amount );
 }

--- a/includes/api-integrations/class-sendgrid-provider.php
+++ b/includes/api-integrations/class-sendgrid-provider.php
@@ -1,4 +1,6 @@
 <?php
+namespace WPAM\Includes;
+
 class WPAM_SendGrid_Provider implements WPAM_API_Provider {
     public function send( $to, $message ) {
         $key = get_option( 'wpam_sendgrid_key' );

--- a/includes/api-integrations/class-twilio-provider.php
+++ b/includes/api-integrations/class-twilio-provider.php
@@ -1,4 +1,6 @@
 <?php
+namespace WPAM\Includes;
+
 class WPAM_Twilio_Provider implements WPAM_API_Provider {
     public function send( $to, $message ) {
         $sid   = get_option( 'wpam_twilio_sid' );

--- a/includes/class-wpam-auction.php
+++ b/includes/class-wpam-auction.php
@@ -1,4 +1,5 @@
 <?php
+namespace WPAM\Includes;
 if ( class_exists( 'WC_Product' ) && ! class_exists( 'WC_Product_Auction' ) ) {
     class WC_Product_Auction extends WC_Product {
         public function get_type() {

--- a/includes/class-wpam-bid.php
+++ b/includes/class-wpam-bid.php
@@ -1,4 +1,6 @@
 <?php
+namespace WPAM\Includes;
+
 class WPAM_Bid {
     protected $realtime_provider;
 

--- a/includes/class-wpam-install.php
+++ b/includes/class-wpam-install.php
@@ -1,4 +1,6 @@
 <?php
+namespace WPAM\Includes;
+
 class WPAM_Install {
     public static function activate() {
         global $wpdb;

--- a/includes/class-wpam-loader.php
+++ b/includes/class-wpam-loader.php
@@ -1,30 +1,19 @@
 <?php
+namespace WPAM\Includes;
+
 class WPAM_Loader {
     public function run() {
         // Load dependencies
         if ( file_exists( WPAM_PLUGIN_DIR . 'vendor/autoload.php' ) ) {
             require_once WPAM_PLUGIN_DIR . 'vendor/autoload.php';
         }
-        require_once WPAM_PLUGIN_DIR . 'includes/class-wpam-auction.php';
-        require_once WPAM_PLUGIN_DIR . 'includes/class-wpam-bid.php';
-        require_once WPAM_PLUGIN_DIR . 'includes/class-wpam-watchlist.php';
-        require_once WPAM_PLUGIN_DIR . 'includes/class-wpam-messages.php';
-        require_once WPAM_PLUGIN_DIR . 'includes/class-wpam-notifications.php';
-        require_once WPAM_PLUGIN_DIR . 'includes/api-integrations/class-api-provider.php';
-        require_once WPAM_PLUGIN_DIR . 'includes/api-integrations/class-twilio-provider.php';
-        require_once WPAM_PLUGIN_DIR . 'includes/api-integrations/class-firebase-provider.php';
-        require_once WPAM_PLUGIN_DIR . 'includes/api-integrations/class-sendgrid-provider.php';
-        require_once WPAM_PLUGIN_DIR . 'admin/class-wpam-admin.php';
-        require_once WPAM_PLUGIN_DIR . 'public/class-wpam-public.php';
-        require_once WPAM_PLUGIN_DIR . 'includes/api-integrations/class-realtime-provider.php';
-        require_once WPAM_PLUGIN_DIR . 'includes/api-integrations/class-pusher-provider.php';
 
         // Init classes
         new WPAM_Auction();
         new WPAM_Bid();
         new WPAM_Watchlist();
         new WPAM_Messages();
-        new WPAM_Admin();
-        new WPAM_Public();
+        new \WPAM\Admin\WPAM_Admin();
+        new \WPAM\Public\WPAM_Public();
     }
 }

--- a/includes/class-wpam-messages.php
+++ b/includes/class-wpam-messages.php
@@ -1,4 +1,6 @@
 <?php
+namespace WPAM\Includes;
+
 class WPAM_Messages {
     public function __construct() {
         add_action( 'wp_ajax_wpam_submit_question', [ $this, 'submit_question' ] );

--- a/includes/class-wpam-notifications.php
+++ b/includes/class-wpam-notifications.php
@@ -1,4 +1,6 @@
 <?php
+namespace WPAM\Includes;
+
 class WPAM_Notifications {
     public static function send_to_user( $user_id, $subject, $message ) {
         $sms_enabled   = get_option( 'wpam_enable_twilio', '0' );

--- a/includes/class-wpam-watchlist.php
+++ b/includes/class-wpam-watchlist.php
@@ -1,4 +1,6 @@
 <?php
+namespace WPAM\Includes;
+
 class WPAM_Watchlist {
     public function __construct() {
         add_action( 'wp_ajax_wpam_toggle_watchlist', [ $this, 'toggle_watchlist' ] );

--- a/public/class-wpam-public.php
+++ b/public/class-wpam-public.php
@@ -1,4 +1,6 @@
 <?php
+namespace WPAM\Public;
+
 class WPAM_Public {
     public function __construct() {
         add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_scripts' ] );

--- a/tests/test-bid-limit.php
+++ b/tests/test-bid-limit.php
@@ -1,4 +1,7 @@
 <?php
+use WPAM\Includes\WPAM_Bid;
+use WPAM\Includes\WPAM_Install;
+
 class Test_WPAM_Bid_Limit extends WP_Ajax_UnitTestCase {
     protected $auction_id;
     protected $user_id;

--- a/tests/test-bid-status.php
+++ b/tests/test-bid-status.php
@@ -1,4 +1,6 @@
 <?php
+use WPAM\Includes\WPAM_Bid;
+
 class Test_WPAM_Bid_Status extends WP_Ajax_UnitTestCase {
     public function set_up() : void {
         parent::set_up();

--- a/tests/test-bid.php
+++ b/tests/test-bid.php
@@ -1,4 +1,6 @@
 <?php
+use WPAM\Includes\WPAM_Bid;
+
 class Test_WPAM_Bid extends WP_Ajax_UnitTestCase {
     public function set_up() : void {
         parent::set_up();

--- a/tests/test-watchlist-auth.php
+++ b/tests/test-watchlist-auth.php
@@ -1,4 +1,7 @@
 <?php
+use WPAM\Includes\WPAM_Watchlist;
+use WPAM\Includes\WPAM_Install;
+
 class Test_WPAM_Watchlist_Auth extends WP_Ajax_UnitTestCase {
     protected $auction_id;
     public function set_up() : void {

--- a/tests/test-watchlist.php
+++ b/tests/test-watchlist.php
@@ -1,4 +1,7 @@
 <?php
+use WPAM\Includes\WPAM_Watchlist;
+use WPAM\Includes\WPAM_Install;
+
 class Test_WPAM_Watchlist extends WP_Ajax_UnitTestCase {
     protected $auction_id;
     public function set_up() : void {

--- a/vendor/composer/autoload_psr4.php
+++ b/vendor/composer/autoload_psr4.php
@@ -6,6 +6,9 @@ $vendorDir = dirname(__DIR__);
 $baseDir = dirname($vendorDir);
 
 return array(
+    'WPAM\\Public\\' => array($baseDir . '/public'),
+    'WPAM\\Includes\\' => array($baseDir . '/includes'),
+    'WPAM\\Admin\\' => array($baseDir . '/admin'),
     'Pusher\\' => array($vendorDir . '/pusher/pusher-php-server/src'),
     'Psr\\Log\\' => array($vendorDir . '/psr/log/src'),
     'Psr\\Http\\Message\\' => array($vendorDir . '/psr/http-factory/src', $vendorDir . '/psr/http-message/src'),

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -14,6 +14,12 @@ class ComposerStaticInit5a9cdac556bc224b8f4676ac39920f7b
     );
 
     public static $prefixLengthsPsr4 = array (
+        'W' => 
+        array (
+            'WPAM\\Public\\' => 12,
+            'WPAM\\Includes\\' => 14,
+            'WPAM\\Admin\\' => 11,
+        ),
         'P' => 
         array (
             'Pusher\\' => 7,
@@ -30,6 +36,18 @@ class ComposerStaticInit5a9cdac556bc224b8f4676ac39920f7b
     );
 
     public static $prefixDirsPsr4 = array (
+        'WPAM\\Public\\' => 
+        array (
+            0 => __DIR__ . '/../..' . '/public',
+        ),
+        'WPAM\\Includes\\' => 
+        array (
+            0 => __DIR__ . '/../..' . '/includes',
+        ),
+        'WPAM\\Admin\\' => 
+        array (
+            0 => __DIR__ . '/../..' . '/admin',
+        ),
         'Pusher\\' => 
         array (
             0 => __DIR__ . '/..' . '/pusher/pusher-php-server/src',

--- a/wp-auction-manager.php
+++ b/wp-auction-manager.php
@@ -18,8 +18,9 @@ define( 'WPAM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'WPAM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'WPAM_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 
-require_once WPAM_PLUGIN_DIR . 'includes/class-wpam-loader.php';
-require_once WPAM_PLUGIN_DIR . 'includes/class-wpam-install.php';
+if ( file_exists( WPAM_PLUGIN_DIR . 'vendor/autoload.php' ) ) {
+    require_once WPAM_PLUGIN_DIR . 'vendor/autoload.php';
+}
 
 /**
  * Load plugin translation files.
@@ -49,11 +50,11 @@ function wpam_activation() {
         );
     }
 
-    WPAM_Install::activate();
+    \WPAM\Includes\WPAM_Install::activate();
 }
 
 function wpam_run_plugin() {
-    $loader = new WPAM_Loader();
+    $loader = new \WPAM\Includes\WPAM_Loader();
     $loader->run();
 }
 


### PR DESCRIPTION
## Summary
- define namespaces for Admin, Includes and Public directories
- update composer autoload to register new namespaces
- update loader and plugin bootstrap for autoload use
- adjust tests to reference namespaced classes

## Testing
- `composer dump-autoload`
- `php -l wp-auction-manager.php`
- `php -l includes/class-wpam-loader.php`


------
https://chatgpt.com/codex/tasks/task_e_6889344c717083339ddf8791aab9004d