### PR TITLE
Add auction block with FSE pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Firebase push notifications are available through the `Enable Firebase` option (
 
 The plugin includes a lightweight React application that can render either a list of auctions or a single auction view. Use the `[wpam_auction_app]` shortcode on any page to load the React interface. When used on a single auction product page the current auction is automatically displayed.
 
+### Auction block
+
+WP Auction Manager ships with a dynamic block registered via `@wordpress/scripts`. Search for **Auction** in the block inserter to add a live countdown, status labels and bid form anywhere within the block editor. Block attributes allow toggling each element and optionally specifying an Auction ID when used outside of the product screen.
+
 ## Running unit tests
 
 A `tests/` directory will contain PHPUnit tests in the future. Once available, install development dependencies and execute:

--- a/includes/class-wpam-blocks.php
+++ b/includes/class-wpam-blocks.php
@@ -1,0 +1,99 @@
+<?php
+namespace WPAM\Includes;
+
+class WPAM_Blocks {
+    public function __construct() {
+        add_action( 'init', [ $this, 'register_blocks' ] );
+        add_action( 'init', [ $this, 'register_patterns' ] );
+    }
+
+    public function register_blocks() {
+        register_block_type(
+            WPAM_PLUGIN_DIR . 'src/blocks/auction',
+            [
+                'render_callback' => [ $this, 'render_auction_block' ],
+            ]
+        );
+    }
+
+    public function register_patterns() {
+        if ( function_exists( 'register_block_pattern' ) ) {
+            $content = '';
+            $file    = WPAM_PLUGIN_DIR . 'patterns/auction-details.php';
+            if ( file_exists( $file ) ) {
+                $content = include $file;
+            }
+
+            register_block_pattern(
+                'wpam/auction-details',
+                [
+                    'title'       => __( 'Auction Details', 'wpam' ),
+                    'description' => __( 'Display auction countdown, status and bid form.', 'wpam' ),
+                    'content'     => $content,
+                    'categories'  => [ 'featured' ],
+                ]
+            );
+        }
+    }
+
+    public function render_auction_block( $attributes ) {
+        $atts = wp_parse_args(
+            $attributes,
+            [
+                'auctionId'     => 0,
+                'showCountdown' => true,
+                'showBidForm'   => true,
+                'showStatus'    => true,
+            ]
+        );
+
+        $auction_id = absint( $atts['auctionId'] );
+        if ( ! $auction_id && is_singular( 'product' ) ) {
+            $product = wc_get_product( get_queried_object_id() );
+            if ( $product && 'auction' === $product->get_type() ) {
+                $auction_id = $product->get_id();
+            }
+        }
+
+        if ( ! $auction_id ) {
+            return '';
+        }
+
+        $end   = get_post_meta( $auction_id, '_auction_end', true );
+        $end_ts = $end ? strtotime( $end ) : 0;
+        $type  = get_post_meta( $auction_id, '_auction_type', true );
+        $status = 'ongoing';
+        $now   = current_time( 'timestamp' );
+        $start = get_post_meta( $auction_id, '_auction_start', true );
+        $start_ts = $start ? strtotime( $start ) : 0;
+        if ( $now < $start_ts ) {
+            $status = 'scheduled';
+        } elseif ( $now > $end_ts ) {
+            $status = 'ended';
+        }
+
+        global $wpdb;
+        $highest = $wpdb->get_var( $wpdb->prepare( "SELECT MAX(bid_amount) FROM {$wpdb->prefix}wc_auction_bids WHERE auction_id = %d", $auction_id ) );
+        $highest = $highest ? floatval( $highest ) : 0;
+
+        ob_start();
+        echo '<div class="wpam-auction-block">';
+        if ( $atts['showStatus'] ) {
+            echo '<p class="wpam-status woocommerce-message">' . esc_html( ucfirst( $status ) ) . '</p>';
+            echo '<p class="wpam-type">' . esc_html( ucfirst( $type ) ) . '</p>';
+        }
+        if ( $atts['showCountdown'] ) {
+            echo '<p class="wpam-countdown" data-end="' . esc_attr( $end_ts ) . '"></p>';
+        }
+        echo '<p>' . esc_html__( 'Current Bid:', 'wpam' ) . ' <span class="wpam-current-bid" data-auction-id="' . esc_attr( $auction_id ) . '">' . esc_html( $highest ) . '</span></p>';
+        if ( $atts['showBidForm'] ) {
+            echo '<form class="wpam-bid-form">';
+            echo '<input type="number" step="0.01" class="wpam-bid-input" />';
+            wp_nonce_field( 'wpam_place_bid', 'wpam_bid_nonce', false );
+            echo '<button class="button wpam-bid-button" data-auction-id="' . esc_attr( $auction_id ) . '">' . esc_html__( 'Place Bid', 'wpam' ) . '</button>';
+            echo '</form>';
+        }
+        echo '</div>';
+        return ob_get_clean();
+    }
+}

--- a/includes/class-wpam-loader.php
+++ b/includes/class-wpam-loader.php
@@ -15,5 +15,6 @@ class WPAM_Loader {
         new WPAM_Messages();
         new \WPAM\Admin\WPAM_Admin();
         new \WPAM\Public\WPAM_Public();
+        new WPAM_Blocks();
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "wp-auction-manager",
+  "version": "1.0.0",
+  "devDependencies": {
+    "@wordpress/scripts": "^26.0.0"
+  },
+  "scripts": {
+    "build": "wp-scripts build",
+    "start": "wp-scripts start"
+  }
+}

--- a/patterns/auction-details.php
+++ b/patterns/auction-details.php
@@ -1,0 +1,2 @@
+<?php
+return '<!-- wp:wpam/auction {"showCountdown":true,"showBidForm":true,"showStatus":true} /-->';

--- a/src/blocks/auction/block.json
+++ b/src/blocks/auction/block.json
@@ -1,0 +1,27 @@
+{
+    "apiVersion": 2,
+    "name": "wpam/auction",
+    "title": "Auction",
+    "category": "widgets",
+    "icon": "hammer",
+    "description": "Display auction countdown and bid form.",
+    "textdomain": "wpam",
+    "attributes": {
+        "auctionId": {
+            "type": "integer"
+        },
+        "showCountdown": {
+            "type": "boolean",
+            "default": true
+        },
+        "showBidForm": {
+            "type": "boolean",
+            "default": true
+        },
+        "showStatus": {
+            "type": "boolean",
+            "default": true
+        }
+    },
+    "editorScript": "file:./index.js"
+}

--- a/src/blocks/auction/index.js
+++ b/src/blocks/auction/index.js
@@ -1,0 +1,43 @@
+import { registerBlockType } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, ToggleControl, TextControl } from '@wordpress/components';
+import metadata from './block.json';
+
+registerBlockType( metadata.name, {
+    edit( { attributes, setAttributes } ) {
+        const { showCountdown, showBidForm, showStatus, auctionId } = attributes;
+        return (
+            <>
+                <InspectorControls>
+                    <PanelBody title={ __( 'Auction Settings', 'wpam' ) }>
+                        <TextControl
+                            label={ __( 'Auction ID (optional)', 'wpam' ) }
+                            value={ auctionId || '' }
+                            onChange={ ( value ) => setAttributes( { auctionId: parseInt( value, 10 ) || 0 } ) }
+                        />
+                        <ToggleControl
+                            label={ __( 'Show Countdown', 'wpam' ) }
+                            checked={ showCountdown }
+                            onChange={ ( val ) => setAttributes( { showCountdown: val } ) }
+                        />
+                        <ToggleControl
+                            label={ __( 'Show Bid Form', 'wpam' ) }
+                            checked={ showBidForm }
+                            onChange={ ( val ) => setAttributes( { showBidForm: val } ) }
+                        />
+                        <ToggleControl
+                            label={ __( 'Show Status Labels', 'wpam' ) }
+                            checked={ showStatus }
+                            onChange={ ( val ) => setAttributes( { showStatus: val } ) }
+                        />
+                    </PanelBody>
+                </InspectorControls>
+                <div { ...useBlockProps() }>{ __( 'Auction Block', 'wpam' ) }</div>
+            </>
+        );
+    },
+    save() {
+        return null;
+    },
+} );


### PR DESCRIPTION
## Summary
- register new `WPAM_Blocks` class
- create dynamic block `wpam/auction`
- load block patterns for FSE themes
- wire the block loader in `WPAM_Loader`
- document the block in README
- add `@wordpress/scripts` dev dependency

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Error establishing a database connection)*
- `vendor/bin/phpcs -q .` *(fails: PHP_CodeSniffer ran out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_688936e21bf883339093786b90ef4458