### PR TITLE
Add basic KYC verification flow

### DIFF
--- a/includes/class-wpam-kyc.php
+++ b/includes/class-wpam-kyc.php
@@ -1,0 +1,64 @@
+<?php
+namespace WPAM\Includes;
+
+use WP_REST_Server;
+use WP_REST_Request;
+
+class WPAM_KYC {
+    public function __construct() {
+        add_action( 'show_user_profile', [ $this, 'profile_field' ] );
+        add_action( 'edit_user_profile', [ $this, 'profile_field' ] );
+        add_action( 'personal_options_update', [ $this, 'save_profile_field' ] );
+        add_action( 'edit_user_profile_update', [ $this, 'save_profile_field' ] );
+
+        add_action( 'rest_api_init', [ $this, 'register_rest_route' ] );
+    }
+
+    public function profile_field( $user ) {
+        ?>
+        <h2><?php esc_html_e( 'KYC Verification', 'wpam' ); ?></h2>
+        <table class="form-table" role="presentation">
+            <tr>
+                <th scope="row"><label for="wpam_kyc_verified"><?php esc_html_e( 'Verified', 'wpam' ); ?></label></th>
+                <td>
+                    <input type="checkbox" name="wpam_kyc_verified" id="wpam_kyc_verified" value="1" <?php checked( get_user_meta( $user->ID, 'wpam_kyc_verified', true ), 1 ); ?> />
+                </td>
+            </tr>
+        </table>
+        <?php
+    }
+
+    public function save_profile_field( $user_id ) {
+        if ( ! current_user_can( 'edit_user', $user_id ) ) {
+            return false;
+        }
+        $value = isset( $_POST['wpam_kyc_verified'] ) ? 1 : 0;
+        update_user_meta( $user_id, 'wpam_kyc_verified', $value );
+    }
+
+    public function register_rest_route() {
+        register_rest_route(
+            'wpam/v1',
+            '/kyc',
+            [
+                'methods'             => WP_REST_Server::CREATABLE,
+                'callback'            => [ $this, 'handle_kyc_submission' ],
+                'permission_callback' => function() {
+                    return is_user_logged_in();
+                },
+                'args'                => [
+                    'id_document' => [
+                        'required' => true,
+                    ],
+                ],
+            ]
+        );
+    }
+
+    public function handle_kyc_submission( WP_REST_Request $request ) {
+        $user_id = get_current_user_id();
+        // In a real system, the document would be processed here.
+        do_action( 'wpam_kyc_submitted', $user_id, $request['id_document'] );
+        return rest_ensure_response( [ 'message' => __( 'Document received', 'wpam' ) ] );
+    }
+}

--- a/includes/class-wpam-loader.php
+++ b/includes/class-wpam-loader.php
@@ -12,6 +12,7 @@ class WPAM_Loader {
         new WPAM_Auction();
         new WPAM_Bid();
         new WPAM_Watchlist();
+        new WPAM_KYC();
         new WPAM_Messages();
         new \WPAM\Admin\WPAM_Admin();
         new \WPAM\Public\WPAM_Public();

--- a/tests/test-kyc.php
+++ b/tests/test-kyc.php
@@ -1,0 +1,55 @@
+<?php
+use WPAM\Includes\WPAM_Bid;
+use WPAM\Includes\WPAM_Install;
+
+class Test_WPAM_KYC extends WP_Ajax_UnitTestCase {
+    protected $auction_id;
+    protected $user_id;
+
+    public function set_up() : void {
+        parent::set_up();
+        new WPAM_Bid();
+        WPAM_Install::activate();
+        update_option( 'wpam_require_kyc', 1 );
+        $this->auction_id = $this->factory->post->create([ 'post_type' => 'product' ]);
+        update_post_meta( $this->auction_id, '_auction_start', date( 'Y-m-d H:i:s', time() - 3600 ) );
+        update_post_meta( $this->auction_id, '_auction_end', date( 'Y-m-d H:i:s', time() + 3600 ) );
+        $this->user_id = $this->factory->user->create();
+        wp_set_current_user( $this->user_id );
+    }
+
+    public function test_bid_rejected_if_unverified() {
+        $_POST = [
+            'nonce'      => wp_create_nonce( 'wpam_place_bid' ),
+            'auction_id' => $this->auction_id,
+            'bid'        => 5,
+        ];
+        try {
+            $this->_handleAjax( 'wpam_place_bid' );
+        } catch ( WPAjaxDieContinueException $e ) {
+            $response = json_decode( $this->_last_response, true );
+            $this->assertFalse( $response['success'] );
+            $this->assertSame( 'Verification required', $response['data']['message'] );
+            return;
+        }
+        $this->fail( 'Expected KYC verification requirement.' );
+    }
+
+    public function test_bid_allowed_when_verified() {
+        update_user_meta( $this->user_id, 'wpam_kyc_verified', 1 );
+        $_POST = [
+            'nonce'      => wp_create_nonce( 'wpam_place_bid' ),
+            'auction_id' => $this->auction_id,
+            'bid'        => 5,
+        ];
+        try {
+            $this->_handleAjax( 'wpam_place_bid' );
+        } catch ( WPAjaxDieContinueException $e ) {
+            $response = json_decode( $this->_last_response, true );
+            $this->assertTrue( $response['success'] );
+            $this->assertSame( 'Bid received', $response['data']['message'] );
+            return;
+        }
+        $this->fail( 'Expected bid success.' );
+    }
+}


### PR DESCRIPTION
## Summary
- add KYC helper class for admin UI and REST route
- initialise KYC class in loader
- add PHPUnit test to verify KYC gate

## Testing
- `composer install` *(installs vendor deps)*
- `bash bin/install-wp-tests.sh wordpress_test root '' localhost latest true` *(failed: network unreachable)*
- `./vendor/bin/phpcs includes/class-wpam-kyc.php`

------
https://chatgpt.com/codex/tasks/task_e_6889396656e883339cdd8d451788e9a9