### PR TITLE
Fix order save after auction ends

### DIFF
--- a/includes/class-wpam-auction.php
+++ b/includes/class-wpam-auction.php
@@ -241,6 +241,7 @@ class WPAM_Auction {
         }
 
         $order->calculate_totals();
+        $order->save();
 
         update_post_meta( $auction_id, '_auction_winner', $user_id );
         update_post_meta( $auction_id, '_auction_order_id', $order->get_id() );


### PR DESCRIPTION
## Summary
- ensure auction order objects are persisted after totals are calculated

## Testing
- `vendor/bin/phpcs -d memory_limit=512M includes/class-wpam-auction.php`
- `bash bin/install-wp-tests.sh wordpress_test root '' localhost latest` *(fails: `mysqladmin: connect to server at 'localhost' failed`)*
- `vendor/bin/phpunit -c tests/wp-tests-config.php --testsuite default` *(fails: `Class \"PHPUnit\\TextUI\\Command\" not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68893e07923c83339d020bb79c8f7b99