### PR TITLE
Fix autoload failure for WooCommerce classes

### DIFF
--- a/includes/class-wpam-auction.php
+++ b/includes/class-wpam-auction.php
@@ -1,7 +1,7 @@
 <?php
 namespace WPAM\Includes;
 if ( class_exists( 'WC_Product' ) && ! class_exists( 'WC_Product_Auction' ) ) {
-    class WC_Product_Auction extends WC_Product {
+    class WC_Product_Auction extends \WC_Product {
         public function get_type() {
             return 'auction';
         }
@@ -233,7 +233,7 @@ class WPAM_Auction {
         $fee = floatval( get_post_meta( $auction_id, '_auction_fee', 0 ) );
         $fee = apply_filters( 'wpam_auction_fee_calculated', $fee, $auction_id, $amount );
         if ( $fee > 0 ) {
-            $item = new WC_Order_Item_Fee();
+            $item = new \WC_Order_Item_Fee();
             $item->set_name( __( 'Auction Fee', 'wpam' ) );
             $item->set_amount( $fee );
             $item->set_total( $fee );

--- a/wp-auction-manager.php
+++ b/wp-auction-manager.php
@@ -22,6 +22,43 @@ if ( file_exists( WPAM_PLUGIN_DIR . 'vendor/autoload.php' ) ) {
     require_once WPAM_PLUGIN_DIR . 'vendor/autoload.php';
 }
 
+// Autoload plugin classes when Composer's autoloader does not map them.
+spl_autoload_register(
+    function ( $class ) {
+        if ( 0 !== strpos( $class, 'WPAM\\' ) ) {
+            return;
+        }
+
+        $parts = explode( '\\', $class );
+        array_shift( $parts ); // Remove "WPAM" namespace root.
+
+        $class_name = array_pop( $parts );
+        $slug       = strtolower( str_replace( '_', '-', $class_name ) );
+
+        $files = [ 'class-' . $slug . '.php' ];
+        if ( 0 === strpos( $slug, 'wpam-' ) ) {
+            $files[] = 'class-' . substr( $slug, 5 ) . '.php';
+        }
+
+        $directories = [
+            WPAM_PLUGIN_DIR . 'includes/',
+            WPAM_PLUGIN_DIR . 'includes/api-integrations/',
+            WPAM_PLUGIN_DIR . 'admin/',
+            WPAM_PLUGIN_DIR . 'public/',
+        ];
+
+        foreach ( $directories as $directory ) {
+            foreach ( $files as $file ) {
+                $path = $directory . $file;
+                if ( file_exists( $path ) ) {
+                    require_once $path;
+                    return;
+                }
+            }
+        }
+    }
+);
+
 /**
  * Load plugin translation files.
  */


### PR DESCRIPTION
## Summary
- use global namespace for `WC_Product` and `WC_Order_Item_Fee` classes

## Testing
- `vendor/bin/phpcs -d memory_limit=512M --standard=phpcs.xml includes/class-wpam-auction.php`
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_6889439165dc8333b4d0dee1beaf7aee