### PR TITLE
Fix namespaced references for admin and integrations

### DIFF
--- a/admin/class-wpam-admin.php
+++ b/admin/class-wpam-admin.php
@@ -10,8 +10,18 @@ class WPAM_Admin {
     }
 
     public function add_menu() {
+        add_menu_page(
+            __( 'Auctions', 'wpam' ),
+            __( 'Auctions', 'wpam' ),
+            'manage_options',
+            'wpam-auctions',
+            [ $this, 'render_auctions_page' ],
+            'dashicons-hammer',
+            56
+        );
+
         add_submenu_page(
-            'woocommerce',
+            'wpam-auctions',
             __( 'All Auctions', 'wpam' ),
             __( 'All Auctions', 'wpam' ),
             'manage_options',
@@ -20,7 +30,7 @@ class WPAM_Admin {
         );
 
         add_submenu_page(
-            'woocommerce',
+            'wpam-auctions',
             __( 'Bids', 'wpam' ),
             __( 'Bids', 'wpam' ),
             'manage_options',
@@ -29,7 +39,7 @@ class WPAM_Admin {
         );
 
         add_submenu_page(
-            'woocommerce',
+            'wpam-auctions',
             __( 'Messages', 'wpam' ),
             __( 'Messages', 'wpam' ),
             'manage_options',
@@ -38,7 +48,7 @@ class WPAM_Admin {
         );
 
         add_submenu_page(
-            'woocommerce',
+            'wpam-auctions',
             __( 'Integrations', 'wpam' ),
             __( 'Settings', 'wpam' ),
             'manage_options',
@@ -401,7 +411,7 @@ class WPAM_Admin {
             'wpam/v1',
             '/settings',
             [
-                'methods'             => WP_REST_Server::READABLE,
+                'methods'             => \WP_REST_Server::READABLE,
                 'callback'            => [ $this, 'rest_get_settings' ],
                 'permission_callback' => function() {
                     return current_user_can( 'manage_options' );
@@ -413,7 +423,7 @@ class WPAM_Admin {
             'wpam/v1',
             '/settings',
             [
-                'methods'             => WP_REST_Server::EDITABLE,
+                'methods'             => \WP_REST_Server::EDITABLE,
                 'callback'            => [ $this, 'rest_update_settings' ],
                 'permission_callback' => function() {
                     return current_user_can( 'manage_options' );
@@ -422,7 +432,7 @@ class WPAM_Admin {
         );
     }
 
-    public function rest_get_settings( WP_REST_Request $request ) {
+    public function rest_get_settings( \WP_REST_Request $request ) {
         $options = [];
         foreach ( $this->get_option_keys() as $key ) {
             $options[ $key ] = get_option( $key );
@@ -431,7 +441,7 @@ class WPAM_Admin {
         return rest_ensure_response( $options );
     }
 
-    public function rest_update_settings( WP_REST_Request $request ) {
+    public function rest_update_settings( \WP_REST_Request $request ) {
         $params = $request->get_json_params();
         foreach ( $this->get_option_keys() as $key ) {
             if ( isset( $params[ $key ] ) ) {

--- a/admin/class-wpam-auctions-table.php
+++ b/admin/class-wpam-auctions-table.php
@@ -63,7 +63,7 @@ class WPAM_Auctions_Table extends \WP_List_Table {
             ];
         }
 
-        $query = new WP_Query( $args );
+        $query = new \WP_Query( $args );
         $items  = [];
         foreach ( $query->posts as $post ) {
             $start = get_post_meta( $post->ID, '_auction_start', true );

--- a/includes/api-integrations/class-firebase-provider.php
+++ b/includes/api-integrations/class-firebase-provider.php
@@ -12,7 +12,7 @@ class WPAM_Firebase_Provider implements WPAM_API_Provider {
     public function send( $token, $message ) {
         $key = get_option( 'wpam_firebase_server_key' );
         if ( ! $key || ! $token ) {
-            return new WP_Error( 'firebase_credentials', __( 'Firebase not configured', 'wpam' ) );
+            return new \WP_Error( 'firebase_credentials', __( 'Firebase not configured', 'wpam' ) );
         }
 
         $body = [
@@ -41,6 +41,6 @@ class WPAM_Firebase_Provider implements WPAM_API_Provider {
             return true;
         }
 
-        return new WP_Error( 'firebase_http', wp_remote_retrieve_body( $response ) );
+        return new \WP_Error( 'firebase_http', wp_remote_retrieve_body( $response ) );
     }
 }

--- a/includes/api-integrations/class-sendgrid-provider.php
+++ b/includes/api-integrations/class-sendgrid-provider.php
@@ -5,7 +5,7 @@ class WPAM_SendGrid_Provider implements WPAM_API_Provider {
     public function send( $to, $message ) {
         $key = get_option( 'wpam_sendgrid_key' );
         if ( ! $key ) {
-            return new WP_Error( 'sendgrid_credentials', __( 'SendGrid API key missing', 'wpam' ) );
+            return new \WP_Error( 'sendgrid_credentials', __( 'SendGrid API key missing', 'wpam' ) );
         }
         $body = [
             'personalizations' => [ [ 'to' => [ [ 'email' => $to ] ] ] ],
@@ -28,6 +28,6 @@ class WPAM_SendGrid_Provider implements WPAM_API_Provider {
         if ( $code >= 200 && $code < 300 ) {
             return true;
         }
-        return new WP_Error( 'sendgrid_http', wp_remote_retrieve_body( $response ) );
+        return new \WP_Error( 'sendgrid_http', wp_remote_retrieve_body( $response ) );
     }
 }

--- a/includes/api-integrations/class-twilio-provider.php
+++ b/includes/api-integrations/class-twilio-provider.php
@@ -8,7 +8,7 @@ class WPAM_Twilio_Provider implements WPAM_API_Provider {
         $from  = get_option( 'wpam_twilio_from' );
 
         if ( ! $sid || ! $token || ! $from ) {
-            return new WP_Error( 'twilio_credentials', __( 'Twilio credentials not configured', 'wpam' ) );
+            return new \WP_Error( 'twilio_credentials', __( 'Twilio credentials not configured', 'wpam' ) );
         }
 
         $endpoint = sprintf( 'https://api.twilio.com/2010-04-01/Accounts/%s/Messages.json', rawurlencode( $sid ) );
@@ -34,6 +34,6 @@ class WPAM_Twilio_Provider implements WPAM_API_Provider {
             return true;
         }
 
-        return new WP_Error( 'twilio_http', wp_remote_retrieve_body( $response ) );
+        return new \WP_Error( 'twilio_http', wp_remote_retrieve_body( $response ) );
     }
 }

--- a/includes/class-wpam-auction.php
+++ b/includes/class-wpam-auction.php
@@ -1,7 +1,7 @@
 <?php
 namespace WPAM\Includes;
 if ( class_exists( 'WC_Product' ) && ! class_exists( 'WC_Product_Auction' ) ) {
-    class WC_Product_Auction extends WC_Product {
+    class WC_Product_Auction extends \WC_Product {
         public function get_type() {
             return 'auction';
         }
@@ -233,7 +233,7 @@ class WPAM_Auction {
         $fee = floatval( get_post_meta( $auction_id, '_auction_fee', 0 ) );
         $fee = apply_filters( 'wpam_auction_fee_calculated', $fee, $auction_id, $amount );
         if ( $fee > 0 ) {
-            $item = new WC_Order_Item_Fee();
+            $item = new \WC_Order_Item_Fee();
             $item->set_name( __( 'Auction Fee', 'wpam' ) );
             $item->set_amount( $fee );
             $item->set_total( $fee );
@@ -292,7 +292,7 @@ class WPAM_Auction {
             ],
         ];
 
-        $query = new WP_Query( $args );
+        $query = new \WP_Query( $args );
         foreach ( $query->posts as $post ) {
             update_post_meta( $post->ID, '_auction_ended', 1 );
             WPAM_Notifications::notify_auction_end( $post->ID );

--- a/wp-auction-manager.php
+++ b/wp-auction-manager.php
@@ -22,6 +22,43 @@ if ( file_exists( WPAM_PLUGIN_DIR . 'vendor/autoload.php' ) ) {
     require_once WPAM_PLUGIN_DIR . 'vendor/autoload.php';
 }
 
+// Autoload plugin classes when Composer's autoloader does not map them.
+spl_autoload_register(
+    function ( $class ) {
+        if ( 0 !== strpos( $class, 'WPAM\\' ) ) {
+            return;
+        }
+
+        $parts = explode( '\\', $class );
+        array_shift( $parts ); // Remove "WPAM" namespace root.
+
+        $class_name = array_pop( $parts );
+        $slug       = strtolower( str_replace( '_', '-', $class_name ) );
+
+        $files = [ 'class-' . $slug . '.php' ];
+        if ( 0 === strpos( $slug, 'wpam-' ) ) {
+            $files[] = 'class-' . substr( $slug, 5 ) . '.php';
+        }
+
+        $directories = [
+            WPAM_PLUGIN_DIR . 'includes/',
+            WPAM_PLUGIN_DIR . 'includes/api-integrations/',
+            WPAM_PLUGIN_DIR . 'admin/',
+            WPAM_PLUGIN_DIR . 'public/',
+        ];
+
+        foreach ( $directories as $directory ) {
+            foreach ( $files as $file ) {
+                $path = $directory . $file;
+                if ( file_exists( $path ) ) {
+                    require_once $path;
+                    return;
+                }
+            }
+        }
+    }
+);
+
 /**
  * Load plugin translation files.
  */


### PR DESCRIPTION
## Summary
- add top-level Auctions menu and submenus
- reference WP REST classes from global namespace
- reference WP_Query in auctions classes
- namespace WP_Error uses in integration providers

## Testing
- `vendor/bin/phpcs -d memory_limit=512M --standard=phpcs.xml admin/class-wpam-admin.php admin/class-wpam-auctions-table.php includes/class-wpam-auction.php includes/api-integrations/class-sendgrid-provider.php includes/api-integrations/class-firebase-provider.php includes/api-integrations/class-twilio-provider.php`
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_6889439165dc8333b4d0dee1beaf7aee