### PR TITLE
Fix admin asset hooks

### DIFF
--- a/admin/class-wpam-admin.php
+++ b/admin/class-wpam-admin.php
@@ -369,9 +369,10 @@ class WPAM_Admin {
 
     public function enqueue_scripts( $hook ) {
         $admin_pages = [
-            'woocommerce_page_wpam-auctions',
-            'woocommerce_page_wpam-bids',
-            'woocommerce_page_wpam-messages',
+            'toplevel_page_wpam-auctions',
+            'wpam-auctions_page_wpam-auctions',
+            'wpam-auctions_page_wpam-bids',
+            'wpam-auctions_page_wpam-messages',
             'wpam-auctions_page_wpam-settings',
         ];
 


### PR DESCRIPTION
## Summary
- ensure admin CSS/JS load on all plugin pages by updating hook names

## Testing
- `php vendor/bin/phpunit` *(fails: Class "PHPUnit\TextUI\Command" not found)*
- `vendor/bin/phpcs admin/class-wpam-admin.php` *(reports errors)*

------
https://chatgpt.com/codex/tasks/task_e_68895228612c83339f5bbd35c49033cd