### PR TITLE
Fix admin page hook names for script loading

### DIFF
--- a/admin/class-wpam-admin.php
+++ b/admin/class-wpam-admin.php
@@ -368,13 +368,13 @@ class WPAM_Admin {
     }
 
     public function enqueue_scripts( $hook ) {
+        $slug        = 'wpam-auctions';
         $admin_pages = [
-            'toplevel_page_wpam-auctions',
-            'auctions_page_wpam-settings',
-            'wpam-auctions_page_wpam-auctions',
-            'wpam-auctions_page_wpam-bids',
-            'wpam-auctions_page_wpam-messages',
-            'wpam-auctions_page_wpam-settings',
+            'toplevel_page_' . $slug,
+            $slug . '_page_wpam-auctions',
+            $slug . '_page_wpam-bids',
+            $slug . '_page_wpam-messages',
+            $slug . '_page_wpam-settings',
         ];
 
         if ( in_array( $hook, $admin_pages, true ) ) {
@@ -386,7 +386,7 @@ class WPAM_Admin {
             );
         }
 
-        if ( 'auctions_page_wpam-settings' !== $hook ) {
+        if ( $slug . '_page_wpam-settings' !== $hook ) {
             return;
         }
 


### PR DESCRIPTION
## Summary
- update admin page hooks in `WPAM_Admin` for consistency with the `wpam-auctions` slug
- check settings page hook using the slug variable

## Testing
- `npm run build`
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Class "PHPUnit\TextUI\Command" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68895bb8e9848333983d79877920bb00