### PR TITLE
Add auction product default option

### DIFF
--- a/admin/class-wpam-admin.php
+++ b/admin/class-wpam-admin.php
@@ -368,6 +368,18 @@ class WPAM_Admin {
     }
 
     public function enqueue_scripts( $hook ) {
+        $screen = get_current_screen();
+
+        if ( 'post-new.php' === $hook && 'product' === $screen->post_type && 'add' === $screen->action ) {
+            wp_enqueue_script(
+                'wpam-select-auction-type',
+                WPAM_PLUGIN_URL . 'admin/js/select-auction-product-type.js',
+                [ 'jquery' ],
+                WPAM_PLUGIN_VERSION,
+                true
+            );
+        }
+
         $slug        = 'auctions';
         $admin_pages = [
             'toplevel_page_wpam-' . $slug,

--- a/admin/js/select-auction-product-type.js
+++ b/admin/js/select-auction-product-type.js
@@ -1,0 +1,3 @@
+jQuery(function($){
+  $('#product-type').val('auction').trigger('change');
+});

--- a/includes/class-wpam-auction.php
+++ b/includes/class-wpam-auction.php
@@ -26,7 +26,7 @@ class WPAM_Auction {
     }
 
     public function add_product_type( $types ) {
-        $types['auction'] = __( 'Auction', 'wpam' );
+        $types['auction'] = __( 'Auction product', 'wpam' );
         return $types;
     }
 


### PR DESCRIPTION
## Summary
- register product type label 'Auction product'
- auto-select auction type on new product screen

## Testing
- `composer install`
- `vendor/bin/phpcs -d memory_limit=512M -q includes admin public templates`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6889d27725b483339836c0ea5c649d8a