### PR TITLE
Implement proxy & silent bidding

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ When editing an auction product you can configure additional options in the **Au
 - **Auto Relist** – automatically relist when no winning bid exists.
 - **Max Bids Per User** – limit how many bids each user can place.
 - **Auction Fee** – extra fee added to the winning bid.
+- **Proxy Bidding** – automatically outbid others up to a maximum amount.
+- **Silent Bidding** – hides all bids until the auction ends.
 
 ### Soft-close settings
 

--- a/public/class-wpam-public.php
+++ b/public/class-wpam-public.php
@@ -147,10 +147,16 @@ class WPAM_Public {
         $highest = $wpdb->get_var( $wpdb->prepare( "SELECT MAX(bid_amount) FROM {$wpdb->prefix}wc_auction_bids WHERE auction_id = %d", $auction_id ) );
         $highest = $highest ? floatval( $highest ) : 0;
 
+        $silent = get_option( 'wpam_enable_silent_bidding' ) && get_post_meta( $auction_id, '_auction_silent_bidding', true );
+        $display_highest = $highest;
+        if ( $silent && $now < $end_ts ) {
+            $display_highest = __( 'Hidden', 'wpam' );
+        }
+
         echo '<p class="wpam-status woocommerce-message">' . esc_html( ucfirst( $status ) ) . '</p>';
         echo '<p class="wpam-type">' . esc_html( ucfirst( $type ) ) . '</p>';
         echo '<p class="wpam-countdown" data-end="' . esc_attr( $end_ts ) . '"></p>';
-        echo '<p>' . esc_html__( 'Current Bid:', 'wpam' ) . ' <span class="wpam-current-bid" data-auction-id="' . esc_attr( $auction_id ) . '">' . esc_html( $highest ) . '</span></p>';
+        echo '<p>' . esc_html__( 'Current Bid:', 'wpam' ) . ' <span class="wpam-current-bid" data-auction-id="' . esc_attr( $auction_id ) . '">' . esc_html( $display_highest ) . '</span></p>';
     }
 
     public function render_bid_form() {


### PR DESCRIPTION
## Summary
- support proxy bidding and silent bidding modes
- respect global settings in Auctions tab
- hide current bid on silent auctions
- document new bidding options

## Testing
- `vendor/bin/phpcs includes/class-wpam-bid.php public/class-wpam-public.php README.md`
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_6889db43c17c833388ba0b1f2fda4237