### PR TITLE
Prepopulate new auction dates and add flatpickr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.3 - 2025-07-31
+- Pre-populate default start and end dates for new auctions.
+- Date fields now use flatpickr for easier selection.
+
 ## 1.0.2 - 2025-07-30
 - Added search box and auction type filter to admin auctions table.
 - Admin pages now enqueue WordPress component styles.

--- a/admin/class-wpam-admin.php
+++ b/admin/class-wpam-admin.php
@@ -386,6 +386,29 @@ class WPAM_Admin {
             );
         }
 
+        if ( in_array( $hook, [ 'post-new.php', 'post.php' ], true ) && 'product' === $screen->post_type ) {
+            wp_enqueue_style(
+                'flatpickr',
+                'https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css',
+                [],
+                '4.6.13'
+            );
+            wp_enqueue_script(
+                'flatpickr',
+                'https://cdn.jsdelivr.net/npm/flatpickr',
+                [],
+                '4.6.13',
+                true
+            );
+            wp_enqueue_script(
+                'wpam-date-picker',
+                WPAM_PLUGIN_URL . 'admin/js/auction-date-picker.js',
+                [ 'jquery', 'flatpickr' ],
+                WPAM_PLUGIN_VERSION,
+                true
+            );
+        }
+
         $slug        = 'auctions';
         $admin_pages = [
             'toplevel_page_wpam-' . $slug,

--- a/admin/js/auction-date-picker.js
+++ b/admin/js/auction-date-picker.js
@@ -1,0 +1,14 @@
+jQuery(function($){
+    if (typeof flatpickr === 'function') {
+        flatpickr('#_auction_start', {
+            enableTime: true,
+            enableSeconds: true,
+            dateFormat: 'Y-m-d H:i:S'
+        });
+        flatpickr('#_auction_end', {
+            enableTime: true,
+            enableSeconds: true,
+            dateFormat: 'Y-m-d H:i:S'
+        });
+    }
+});

--- a/includes/class-wpam-auction.php
+++ b/includes/class-wpam-auction.php
@@ -73,10 +73,21 @@ class WPAM_Auction {
             'value'       => get_post_meta( $post_id, '_auction_type', true ),
         ]);
 
-        $start_value   = get_post_meta( $post_id, '_auction_start', true );
         $timezone      = wp_timezone();
-        $start_timestamp = $start_value ? ( new \DateTimeImmutable( $start_value, $timezone ) )->getTimestamp() : false;
-        $is_past_start   = $start_timestamp && $start_timestamp < ( new \DateTimeImmutable( 'now', $timezone ) )->getTimestamp();
+        $current_ts    = current_datetime()->getTimestamp();
+        $start_value   = get_post_meta( $post_id, '_auction_start', true );
+
+        if ( ! $start_value ) {
+            $start_value = wp_date( 'Y-m-d H:i:s', $current_ts + HOUR_IN_SECONDS, $timezone );
+        }
+
+        $start_timestamp = ( new \DateTimeImmutable( $start_value, $timezone ) )->getTimestamp();
+        $is_past_start   = $start_timestamp < $current_ts;
+
+        $end_value = get_post_meta( $post_id, '_auction_end', true );
+        if ( ! $end_value ) {
+            $end_value = wp_date( 'Y-m-d H:i:s', $start_timestamp + DAY_IN_SECONDS, $timezone );
+        }
 
         woocommerce_wp_text_input([
             'id'          => '_auction_start',
@@ -98,7 +109,7 @@ class WPAM_Auction {
             'type'        => 'datetime-local',
             'description' => __( 'When the auction will close.', 'wpam' ),
             'desc_tip'    => true,
-            'value'       => get_post_meta( $post_id, '_auction_end', true ),
+            'value'       => $end_value,
         ]);
 
         woocommerce_wp_text_input([

--- a/wp-auction-manager.php
+++ b/wp-auction-manager.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: WP Auction Manager
 Description: Convert WooCommerce products into auctions with optional real-time and notification integrations.
-Version: 1.0.2
+Version: 1.0.3
 Author: Muzammil Hussain
 Author URI: https://muzammil.dev
 Uninstall: uninstall.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 
-define( 'WPAM_PLUGIN_VERSION', '1.0.2' );
+define( 'WPAM_PLUGIN_VERSION', '1.0.3' );
 define( 'WPAM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'WPAM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'WPAM_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
## Summary
- default auction start time is set to current time + 1 hour
- default end time is set 1 day after the start time
- enqueue flatpickr on product screens
- add JS helper to init date pickers
- bump version to 1.0.3 and document changes

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: displays usage)*
- `vendor/bin/phpcs wp-auction-manager.php admin/class-wpam-admin.php includes/class-wpam-auction.php admin/js/auction-date-picker.js` *(reports multiple coding standard errors)*

------
https://chatgpt.com/codex/tasks/task_e_6889f5e6e61c833387648c59ca305382