### PR TITLE
Add state tracking for auctions

### DIFF
--- a/admin/class-wpam-auctions-table.php
+++ b/admin/class-wpam-auctions-table.php
@@ -2,158 +2,160 @@
 namespace WPAM\Admin;
 
 if ( ! class_exists( 'WP_List_Table' ) ) {
-    require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+	require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
 }
 
 class WPAM_Auctions_Table extends \WP_List_Table {
-    protected $auction_type = '';
+	protected $auction_type = '';
 
-    public function prepare_items() {
-        $status       = isset( $_GET['status'] ) ? sanitize_text_field( wp_unslash( $_GET['status'] ) ) : '';
-        $this->auction_type = isset( $_GET['auction_type'] ) ? sanitize_text_field( wp_unslash( $_GET['auction_type'] ) ) : '';
-        $search       = isset( $_REQUEST['s'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['s'] ) ) : '';
-        $args = [
-            'post_type'      => 'product',
-            'posts_per_page' => 20,
-            'paged'          => $this->get_pagenum(),
-            's'              => $search,
-            'tax_query'      => [
-                [
-                    'taxonomy' => 'product_type',
-                    'field'    => 'slug',
-                    'terms'    => 'auction',
-                ],
-            ],
-            'meta_query'     => [],
-        ];
-        $now = current_time( 'mysql' );
-        if ( $this->auction_type ) {
-            $args['meta_query'][] = [
-                'key'   => '_auction_type',
-                'value' => $this->auction_type,
-            ];
-        }
+	public function prepare_items() {
+		$status             = isset( $_GET['status'] ) ? sanitize_text_field( wp_unslash( $_GET['status'] ) ) : '';
+		$this->auction_type = isset( $_GET['auction_type'] ) ? sanitize_text_field( wp_unslash( $_GET['auction_type'] ) ) : '';
+		$search             = isset( $_REQUEST['s'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['s'] ) ) : '';
+		$args               = array(
+			'post_type'      => 'product',
+			'posts_per_page' => 20,
+			'paged'          => $this->get_pagenum(),
+			's'              => $search,
+			'tax_query'      => array(
+				array(
+					'taxonomy' => 'product_type',
+					'field'    => 'slug',
+					'terms'    => 'auction',
+				),
+			),
+			'meta_query'     => array(),
+		);
+		$now                = current_time( 'mysql' );
+		if ( $this->auction_type ) {
+			$args['meta_query'][] = array(
+				'key'   => '_auction_type',
+				'value' => $this->auction_type,
+			);
+		}
 
-        if ( 'upcoming' === $status ) {
-            $args['meta_query'][] = [
-                'key'     => '_auction_start',
-                'value'   => $now,
-                'compare' => '>',
-                'type'    => 'DATETIME',
-            ];
-        } elseif ( 'ended' === $status ) {
-            $args['meta_query'][] = [
-                'key'     => '_auction_end',
-                'value'   => $now,
-                'compare' => '<',
-                'type'    => 'DATETIME',
-            ];
-        } elseif ( 'active' === $status ) {
-            $args['meta_query'][] = [
-                'key'     => '_auction_start',
-                'value'   => $now,
-                'compare' => '<=',
-                'type'    => 'DATETIME',
-            ];
-            $args['meta_query'][] = [
-                'key'     => '_auction_end',
-                'value'   => $now,
-                'compare' => '>=',
-                'type'    => 'DATETIME',
-            ];
-        }
+		if ( 'upcoming' === $status ) {
+			$args['meta_query'][] = array(
+				'key'     => '_auction_start',
+				'value'   => $now,
+				'compare' => '>',
+				'type'    => 'DATETIME',
+			);
+		} elseif ( 'ended' === $status ) {
+			$args['meta_query'][] = array(
+				'key'     => '_auction_end',
+				'value'   => $now,
+				'compare' => '<',
+				'type'    => 'DATETIME',
+			);
+		} elseif ( 'active' === $status ) {
+			$args['meta_query'][] = array(
+				'key'     => '_auction_start',
+				'value'   => $now,
+				'compare' => '<=',
+				'type'    => 'DATETIME',
+			);
+			$args['meta_query'][] = array(
+				'key'     => '_auction_end',
+				'value'   => $now,
+				'compare' => '>=',
+				'type'    => 'DATETIME',
+			);
+		}
 
-        $query = new \WP_Query( $args );
-        $items  = [];
-        foreach ( $query->posts as $post ) {
-            $start = get_post_meta( $post->ID, '_auction_start', true );
-            $end   = get_post_meta( $post->ID, '_auction_end', true );
-            $items[] = [
-                'ID'    => $post->ID,
-                'title' => $post->post_title,
-                'start' => $start,
-                'end'   => $end,
-            ];
-        }
-        $this->items = $items;
-        $this->set_pagination_args( [
-            'total_items' => $query->found_posts,
-            'per_page'    => 20,
-            'total_pages' => $query->max_num_pages,
-        ] );
-    }
+		$query = new \WP_Query( $args );
+		$items = array();
+		foreach ( $query->posts as $post ) {
+			$start   = get_post_meta( $post->ID, '_auction_start', true );
+			$end     = get_post_meta( $post->ID, '_auction_end', true );
+			$state   = get_post_meta( $post->ID, '_auction_state', true );
+			$reason  = get_post_meta( $post->ID, '_auction_ending_reason', true );
+			$items[] = array(
+				'ID'     => $post->ID,
+				'title'  => $post->post_title,
+				'start'  => $start,
+				'end'    => $end,
+				'state'  => $state,
+				'reason' => $reason,
+			);
+		}
+		$this->items = $items;
+		$this->set_pagination_args(
+			array(
+				'total_items' => $query->found_posts,
+				'per_page'    => 20,
+				'total_pages' => $query->max_num_pages,
+			)
+		);
+	}
 
-    protected function extra_tablenav( $which ) {
-        if ( 'top' !== $which ) {
-            return;
-        }
+	protected function extra_tablenav( $which ) {
+		if ( 'top' !== $which ) {
+			return;
+		}
 
-        echo '<div class="alignleft actions wpam-auctions-filter">';
-        echo '<select name="auction_type">';
-        echo '<option value="">' . esc_html__( 'All Types', 'wpam' ) . '</option>';
-        echo '<option value="standard"' . selected( $this->auction_type, 'standard', false ) . '>' . esc_html__( 'Standard', 'wpam' ) . '</option>';
-        echo '<option value="reverse"' . selected( $this->auction_type, 'reverse', false ) . '>' . esc_html__( 'Reverse', 'wpam' ) . '</option>';
-        echo '<option value="sealed"' . selected( $this->auction_type, 'sealed', false ) . '>' . esc_html__( 'Sealed', 'wpam' ) . '</option>';
-        echo '</select>';
-        submit_button( __( 'Filter', 'wpam' ), '', 'filter_action', false );
-        echo '</div>';
-    }
+		echo '<div class="alignleft actions wpam-auctions-filter">';
+		echo '<select name="auction_type">';
+		echo '<option value="">' . esc_html__( 'All Types', 'wpam' ) . '</option>';
+		echo '<option value="standard"' . selected( $this->auction_type, 'standard', false ) . '>' . esc_html__( 'Standard', 'wpam' ) . '</option>';
+		echo '<option value="reverse"' . selected( $this->auction_type, 'reverse', false ) . '>' . esc_html__( 'Reverse', 'wpam' ) . '</option>';
+		echo '<option value="sealed"' . selected( $this->auction_type, 'sealed', false ) . '>' . esc_html__( 'Sealed', 'wpam' ) . '</option>';
+		echo '</select>';
+		submit_button( __( 'Filter', 'wpam' ), '', 'filter_action', false );
+		echo '</div>';
+	}
 
-    public function get_columns() {
-        return [
-            'title'  => __( 'Auction', 'wpam' ),
-            'start'  => __( 'Start', 'wpam' ),
-            'end'    => __( 'End', 'wpam' ),
-            'status' => __( 'Status', 'wpam' ),
-        ];
-    }
+	public function get_columns() {
+		return array(
+			'title'  => __( 'Auction', 'wpam' ),
+			'start'  => __( 'Start', 'wpam' ),
+			'end'    => __( 'End', 'wpam' ),
+			'state'  => __( 'State', 'wpam' ),
+			'reason' => __( 'Ending Reason', 'wpam' ),
+		);
+	}
 
-    protected function column_title( $item ) {
-        $edit_link = get_edit_post_link( $item['ID'] );
-        $view_bids = add_query_arg(
-            [
-                'page'       => 'wpam-bids',
-                'auction_id' => $item['ID'],
-            ],
-            admin_url( 'admin.php' )
-        );
-        $title   = '<strong><a href="' . esc_url( $edit_link ) . '">' . esc_html( $item['title'] ) . '</a></strong>';
-        $actions = [
-            'edit' => '<a href="' . esc_url( $edit_link ) . '">' . __( 'Edit', 'wpam' ) . '</a>',
-            'bids' => '<a href="' . esc_url( $view_bids ) . '">' . __( 'View Bids', 'wpam' ) . '</a>',
-        ];
-        return $title . $this->row_actions( $actions );
-    }
+	protected function column_title( $item ) {
+		$edit_link = get_edit_post_link( $item['ID'] );
+		$view_bids = add_query_arg(
+			array(
+				'page'       => 'wpam-bids',
+				'auction_id' => $item['ID'],
+			),
+			admin_url( 'admin.php' )
+		);
+		$title     = '<strong><a href="' . esc_url( $edit_link ) . '">' . esc_html( $item['title'] ) . '</a></strong>';
+		$actions   = array(
+			'edit' => '<a href="' . esc_url( $edit_link ) . '">' . __( 'Edit', 'wpam' ) . '</a>',
+			'bids' => '<a href="' . esc_url( $view_bids ) . '">' . __( 'View Bids', 'wpam' ) . '</a>',
+		);
+		return $title . $this->row_actions( $actions );
+	}
 
-    protected function column_status( $item ) {
-        $now   = current_time( 'timestamp' );
-        $start = strtotime( $item['start'] );
-        $end   = strtotime( $item['end'] );
-        if ( $start > $now ) {
-            return __( 'Upcoming', 'wpam' );
-        } elseif ( $end < $now ) {
-            return __( 'Ended', 'wpam' );
-        } else {
-            return __( 'Active', 'wpam' );
-        }
-    }
+	protected function column_state( $item ) {
+		return ucfirst( $item['state'] );
+	}
 
-    public function get_views() {
-        $current  = isset( $_GET['status'] ) ? sanitize_text_field( wp_unslash( $_GET['status'] ) ) : '';
-        $base_url = remove_query_arg( [ 'status', 'paged' ] );
-        $views    = [];
-        $views['all']      = sprintf( '<a href="%s"%s>%s</a>', esc_url( $base_url ), $current === '' ? ' class="current"' : '', __( 'All', 'wpam' ) );
-        $views['upcoming'] = sprintf( '<a href="%s"%s>%s</a>', esc_url( add_query_arg( 'status', 'upcoming', $base_url ) ), $current === 'upcoming' ? ' class="current"' : '', __( 'Upcoming', 'wpam' ) );
-        $views['active']   = sprintf( '<a href="%s"%s>%s</a>', esc_url( add_query_arg( 'status', 'active', $base_url ) ), $current === 'active' ? ' class="current"' : '', __( 'Active', 'wpam' ) );
-        $views['ended']    = sprintf( '<a href="%s"%s>%s</a>', esc_url( add_query_arg( 'status', 'ended', $base_url ) ), $current === 'ended' ? ' class="current"' : '', __( 'Ended', 'wpam' ) );
-        return $views;
-    }
+	protected function column_reason( $item ) {
+		return $item['reason'];
+	}
 
-    public function no_items() {
-        _e( 'No auctions found.', 'wpam' );
-    }
+	public function get_views() {
+		$current           = isset( $_GET['status'] ) ? sanitize_text_field( wp_unslash( $_GET['status'] ) ) : '';
+		$base_url          = remove_query_arg( array( 'status', 'paged' ) );
+		$views             = array();
+		$views['all']      = sprintf( '<a href="%s"%s>%s</a>', esc_url( $base_url ), $current === '' ? ' class="current"' : '', __( 'All', 'wpam' ) );
+		$views['upcoming'] = sprintf( '<a href="%s"%s>%s</a>', esc_url( add_query_arg( 'status', 'upcoming', $base_url ) ), $current === 'upcoming' ? ' class="current"' : '', __( 'Upcoming', 'wpam' ) );
+		$views['active']   = sprintf( '<a href="%s"%s>%s</a>', esc_url( add_query_arg( 'status', 'active', $base_url ) ), $current === 'active' ? ' class="current"' : '', __( 'Active', 'wpam' ) );
+		$views['ended']    = sprintf( '<a href="%s"%s>%s</a>', esc_url( add_query_arg( 'status', 'ended', $base_url ) ), $current === 'ended' ? ' class="current"' : '', __( 'Ended', 'wpam' ) );
+		return $views;
+	}
 
-    protected function column_default( $item, $column_name ) {
-        return isset( $item[ $column_name ] ) ? esc_html( $item[ $column_name ] ) : '';
-    }
+	public function no_items() {
+		_e( 'No auctions found.', 'wpam' );
+	}
+
+	protected function column_default( $item, $column_name ) {
+		return isset( $item[ $column_name ] ) ? esc_html( $item[ $column_name ] ) : '';
+	}
 }

--- a/includes/class-wpam-auction-state.php
+++ b/includes/class-wpam-auction-state.php
@@ -1,0 +1,18 @@
+<?php
+namespace WPAM\Includes;
+
+class WPAM_Auction_State {
+	const SCHEDULED      = 'scheduled';
+	const ABOUT_TO_START = 'about_to_start';
+	const LIVE           = 'live';
+	const ENDED          = 'ended';
+
+	public static function all() {
+		return array(
+			self::SCHEDULED,
+			self::ABOUT_TO_START,
+			self::LIVE,
+			self::ENDED,
+		);
+	}
+}

--- a/includes/class-wpam-blocks.php
+++ b/includes/class-wpam-blocks.php
@@ -59,18 +59,10 @@ class WPAM_Blocks {
             return '';
         }
 
-        $end   = get_post_meta( $auction_id, '_auction_end', true );
+        $end    = get_post_meta( $auction_id, '_auction_end', true );
         $end_ts = $end ? strtotime( $end ) : 0;
-        $type  = get_post_meta( $auction_id, '_auction_type', true );
-        $status = 'ongoing';
-        $now   = current_time( 'timestamp' );
-        $start = get_post_meta( $auction_id, '_auction_start', true );
-        $start_ts = $start ? strtotime( $start ) : 0;
-        if ( $now < $start_ts ) {
-            $status = 'scheduled';
-        } elseif ( $now > $end_ts ) {
-            $status = 'ended';
-        }
+        $type   = get_post_meta( $auction_id, '_auction_type', true );
+        $status = get_post_meta( $auction_id, '_auction_state', true );
 
         global $wpdb;
         $highest = $wpdb->get_var( $wpdb->prepare( "SELECT MAX(bid_amount) FROM {$wpdb->prefix}wc_auction_bids WHERE auction_id = %d", $auction_id ) );

--- a/public/class-wpam-public.php
+++ b/public/class-wpam-public.php
@@ -2,190 +2,183 @@
 namespace WPAM\Public;
 
 class WPAM_Public {
-    public function __construct() {
-        add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
-        add_shortcode( 'wpam_auction_app', [ $this, 'render_react_app' ] );
+	public function __construct() {
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_shortcode( 'wpam_auction_app', array( $this, 'render_react_app' ) );
 
-        // Register template loader on init so custom templates can be swapped in.
-        add_action( 'init', [ $this, 'register_template_hook' ] );
-    }
+		// Register template loader on init so custom templates can be swapped in.
+		add_action( 'init', array( $this, 'register_template_hook' ) );
+	}
 
-    /**
-     * Hook the template loader filter.
-     */
-    public function register_template_hook() {
-        add_filter( 'template_include', [ $this, 'template_loader' ] );
-    }
+	/**
+	 * Hook the template loader filter.
+	 */
+	public function register_template_hook() {
+		add_filter( 'template_include', array( $this, 'template_loader' ) );
+	}
 
-    /**
-     * Conditionally load custom templates for auction views.
-     *
-     * @param string $template Current template path.
-     *
-     * @return string
-     */
-    public function template_loader( $template ) {
-        if ( is_singular( 'product' ) ) {
-            $product = wc_get_product( get_queried_object_id() );
-            if ( $product && 'auction' === $product->get_type() ) {
-                $this->enqueue_scripts();
-                add_action( 'woocommerce_single_product_summary', [ $this, 'render_auction_meta' ], 6 );
-                add_action( 'woocommerce_single_product_summary', [ $this, 'render_bid_form' ], 25 );
-                add_action( 'woocommerce_single_product_summary', [ $this, 'render_watchlist_button' ], 26 );
-                add_action( 'woocommerce_single_product_summary', [ $this, 'render_messages' ], 30 );
-            }
-        }
+	/**
+	 * Conditionally load custom templates for auction views.
+	 *
+	 * @param string $template Current template path.
+	 *
+	 * @return string
+	 */
+	public function template_loader( $template ) {
+		if ( is_singular( 'product' ) ) {
+			$product = wc_get_product( get_queried_object_id() );
+			if ( $product && 'auction' === $product->get_type() ) {
+				$this->enqueue_scripts();
+				add_action( 'woocommerce_single_product_summary', array( $this, 'render_auction_meta' ), 6 );
+				add_action( 'woocommerce_single_product_summary', array( $this, 'render_bid_form' ), 25 );
+				add_action( 'woocommerce_single_product_summary', array( $this, 'render_watchlist_button' ), 26 );
+				add_action( 'woocommerce_single_product_summary', array( $this, 'render_messages' ), 30 );
+			}
+		}
 
-        if ( is_tax( 'product_type', 'auction' ) ) {
-            $this->enqueue_scripts();
+		if ( is_tax( 'product_type', 'auction' ) ) {
+			$this->enqueue_scripts();
 
-            $custom = WPAM_PLUGIN_DIR . 'templates/auction-listing.php';
-            return file_exists( $custom ) ? $custom : $template;
-        }
+			$custom = WPAM_PLUGIN_DIR . 'templates/auction-listing.php';
+			return file_exists( $custom ) ? $custom : $template;
+		}
 
-        return $template;
-    }
+		return $template;
+	}
 
-    public function enqueue_scripts() {
-        $provider       = get_option( 'wpam_realtime_provider', 'none' );
-        $pusher_enabled = ( 'pusher' === $provider );
+	public function enqueue_scripts() {
+		$provider       = get_option( 'wpam_realtime_provider', 'none' );
+		$pusher_enabled = ( 'pusher' === $provider );
 
-        if ( $pusher_enabled ) {
-            wp_enqueue_script( 'pusher-js', 'https://js.pusher.com/7.2/pusher.min.js', [], '7.2', true );
-        }
+		if ( $pusher_enabled ) {
+			wp_enqueue_script( 'pusher-js', 'https://js.pusher.com/7.2/pusher.min.js', array(), '7.2', true );
+		}
 
-        wp_enqueue_style( 'wpam-frontend', WPAM_PLUGIN_URL . 'public/css/wpam-frontend.css', [ 'woocommerce-general' ], WPAM_PLUGIN_VERSION );
+		wp_enqueue_style( 'wpam-frontend', WPAM_PLUGIN_URL . 'public/css/wpam-frontend.css', array( 'woocommerce-general' ), WPAM_PLUGIN_VERSION );
 
-        wp_enqueue_script( 'wpam-ajax-bid', WPAM_PLUGIN_URL . 'public/js/ajax-bid.js', [ 'jquery' ], WPAM_PLUGIN_VERSION, true );
-        wp_localize_script(
-            'wpam-ajax-bid',
-            'wpam_ajax',
-            [
-                'ajax_url'        => admin_url( 'admin-ajax.php' ),
-                'bid_nonce'       => wp_create_nonce( 'wpam_place_bid' ),
-                'watchlist_nonce' => wp_create_nonce( 'wpam_toggle_watchlist' ),
-                'watchlist_get_nonce' => wp_create_nonce( 'wpam_get_watchlist' ),
-                'highest_nonce'   => wp_create_nonce( 'wpam_get_highest_bid' ),
-                'pusher_enabled'  => $pusher_enabled,
-                'pusher_key'      => get_option( 'wpam_pusher_key' ),
-                'pusher_cluster'  => get_option( 'wpam_pusher_cluster' ),
-                'pusher_channel'  => 'wpam-auctions',
-            ]
-        );
+		wp_enqueue_script( 'wpam-ajax-bid', WPAM_PLUGIN_URL . 'public/js/ajax-bid.js', array( 'jquery' ), WPAM_PLUGIN_VERSION, true );
+		wp_localize_script(
+			'wpam-ajax-bid',
+			'wpam_ajax',
+			array(
+				'ajax_url'            => admin_url( 'admin-ajax.php' ),
+				'bid_nonce'           => wp_create_nonce( 'wpam_place_bid' ),
+				'watchlist_nonce'     => wp_create_nonce( 'wpam_toggle_watchlist' ),
+				'watchlist_get_nonce' => wp_create_nonce( 'wpam_get_watchlist' ),
+				'highest_nonce'       => wp_create_nonce( 'wpam_get_highest_bid' ),
+				'pusher_enabled'      => $pusher_enabled,
+				'pusher_key'          => get_option( 'wpam_pusher_key' ),
+				'pusher_cluster'      => get_option( 'wpam_pusher_cluster' ),
+				'pusher_channel'      => 'wpam-auctions',
+			)
+		);
 
-        wp_enqueue_script( 'wpam-ajax-messages', WPAM_PLUGIN_URL . 'public/js/ajax-messages.js', [ 'jquery' ], WPAM_PLUGIN_VERSION, true );
-        wp_localize_script(
-            'wpam-ajax-messages',
-            'wpam_messages',
-            [
-                'ajax_url'      => admin_url( 'admin-ajax.php' ),
-                'message_nonce' => wp_create_nonce( 'wpam_submit_question' ),
-                'get_messages_nonce' => wp_create_nonce( 'wpam_get_messages' ),
-            ]
-        );
+		wp_enqueue_script( 'wpam-ajax-messages', WPAM_PLUGIN_URL . 'public/js/ajax-messages.js', array( 'jquery' ), WPAM_PLUGIN_VERSION, true );
+		wp_localize_script(
+			'wpam-ajax-messages',
+			'wpam_messages',
+			array(
+				'ajax_url'           => admin_url( 'admin-ajax.php' ),
+				'message_nonce'      => wp_create_nonce( 'wpam_submit_question' ),
+				'get_messages_nonce' => wp_create_nonce( 'wpam_get_messages' ),
+			)
+		);
 
-        wp_register_script(
-            'wpam-react-app',
-            WPAM_PLUGIN_URL . 'public/js/react/auction-app.js',
-            [ 'wp-element', 'wp-api-fetch' ],
-            WPAM_PLUGIN_VERSION,
-            true
-        );
-        wp_localize_script(
-            'wpam-react-app',
-            'wpamReactData',
-            [
-                'ajax_url'        => admin_url( 'admin-ajax.php' ),
-                'bid_nonce'       => wp_create_nonce( 'wpam_place_bid' ),
-                'watchlist_nonce' => wp_create_nonce( 'wpam_toggle_watchlist' ),
-                'message_nonce'   => wp_create_nonce( 'wpam_submit_question' ),
-                'get_messages_nonce' => wp_create_nonce( 'wpam_get_messages' ),
-                'highest_nonce'   => wp_create_nonce( 'wpam_get_highest_bid' ),
-                'pusher_enabled'  => $pusher_enabled,
-                'pusher_key'      => get_option( 'wpam_pusher_key' ),
-                'pusher_cluster'  => get_option( 'wpam_pusher_cluster' ),
-                'pusher_channel'  => 'wpam-auctions',
-            ]
-        );
-    }
+		wp_register_script(
+			'wpam-react-app',
+			WPAM_PLUGIN_URL . 'public/js/react/auction-app.js',
+			array( 'wp-element', 'wp-api-fetch' ),
+			WPAM_PLUGIN_VERSION,
+			true
+		);
+		wp_localize_script(
+			'wpam-react-app',
+			'wpamReactData',
+			array(
+				'ajax_url'           => admin_url( 'admin-ajax.php' ),
+				'bid_nonce'          => wp_create_nonce( 'wpam_place_bid' ),
+				'watchlist_nonce'    => wp_create_nonce( 'wpam_toggle_watchlist' ),
+				'message_nonce'      => wp_create_nonce( 'wpam_submit_question' ),
+				'get_messages_nonce' => wp_create_nonce( 'wpam_get_messages' ),
+				'highest_nonce'      => wp_create_nonce( 'wpam_get_highest_bid' ),
+				'pusher_enabled'     => $pusher_enabled,
+				'pusher_key'         => get_option( 'wpam_pusher_key' ),
+				'pusher_cluster'     => get_option( 'wpam_pusher_cluster' ),
+				'pusher_channel'     => 'wpam-auctions',
+			)
+		);
+	}
 
-    public function render_react_app( $atts = [] ) {
-        $auction_id = 0;
+	public function render_react_app( $atts = array() ) {
+		$auction_id = 0;
 
-        if ( ! empty( $atts['auction'] ) ) {
-            $auction_id = absint( $atts['auction'] );
-        } elseif ( is_singular( 'product' ) ) {
-            $product = wc_get_product( get_the_ID() );
-            if ( $product && 'auction' === $product->get_type() ) {
-                $auction_id = get_the_ID();
-            }
-        }
+		if ( ! empty( $atts['auction'] ) ) {
+			$auction_id = absint( $atts['auction'] );
+		} elseif ( is_singular( 'product' ) ) {
+			$product = wc_get_product( get_the_ID() );
+			if ( $product && 'auction' === $product->get_type() ) {
+				$auction_id = get_the_ID();
+			}
+		}
 
-        wp_enqueue_script( 'wpam-react-app' );
-        wp_localize_script( 'wpam-react-app', 'wpamReactPage', [ 'auction_id' => $auction_id ] );
+		wp_enqueue_script( 'wpam-react-app' );
+		wp_localize_script( 'wpam-react-app', 'wpamReactPage', array( 'auction_id' => $auction_id ) );
 
-        return '<div id="wpam-react-root"></div>';
-    }
+		return '<div id="wpam-react-root"></div>';
+	}
 
-    public function render_auction_meta() {
-        global $product;
-        $auction_id = $product->get_id();
-        $end = get_post_meta( $auction_id, '_auction_end', true );
-        $end_ts = $end ? strtotime( $end ) : 0;
-        $type = get_post_meta( $auction_id, '_auction_type', true );
-        $status = 'ongoing';
-        $now = current_time( 'timestamp' );
-        $start = get_post_meta( $auction_id, '_auction_start', true );
-        $start_ts = $start ? strtotime( $start ) : 0;
-        if ( $now < $start_ts ) {
-            $status = 'scheduled';
-        } elseif ( $now > $end_ts ) {
-            $status = 'ended';
-        }
+	public function render_auction_meta() {
+		global $product;
+		$auction_id = $product->get_id();
+		$end        = get_post_meta( $auction_id, '_auction_end', true );
+		$end_ts     = $end ? strtotime( $end ) : 0;
+		$type       = get_post_meta( $auction_id, '_auction_type', true );
+		$status     = get_post_meta( $auction_id, '_auction_state', true );
+		$now        = current_time( 'timestamp' );
 
-        global $wpdb;
-        $highest = $wpdb->get_var( $wpdb->prepare( "SELECT MAX(bid_amount) FROM {$wpdb->prefix}wc_auction_bids WHERE auction_id = %d", $auction_id ) );
-        $highest = $highest ? floatval( $highest ) : 0;
+		global $wpdb;
+		$highest = $wpdb->get_var( $wpdb->prepare( "SELECT MAX(bid_amount) FROM {$wpdb->prefix}wc_auction_bids WHERE auction_id = %d", $auction_id ) );
+		$highest = $highest ? floatval( $highest ) : 0;
 
-        $silent = get_option( 'wpam_enable_silent_bidding' ) && get_post_meta( $auction_id, '_auction_silent_bidding', true );
-        $display_highest = $highest;
-        if ( $silent && $now < $end_ts ) {
-            $display_highest = __( 'Hidden', 'wpam' );
-        }
+		$silent          = get_option( 'wpam_enable_silent_bidding' ) && get_post_meta( $auction_id, '_auction_silent_bidding', true );
+		$display_highest = $highest;
+		if ( $silent && $now < $end_ts ) {
+			$display_highest = __( 'Hidden', 'wpam' );
+		}
 
-        echo '<p class="wpam-status woocommerce-message">' . esc_html( ucfirst( $status ) ) . '</p>';
-        echo '<p class="wpam-type">' . esc_html( ucfirst( $type ) ) . '</p>';
-        echo '<p class="wpam-countdown" data-end="' . esc_attr( $end_ts ) . '"></p>';
-        echo '<p>' . esc_html__( 'Current Bid:', 'wpam' ) . ' <span class="wpam-current-bid" data-auction-id="' . esc_attr( $auction_id ) . '">' . esc_html( $display_highest ) . '</span></p>';
-    }
+		echo '<p class="wpam-status woocommerce-message">' . esc_html( ucfirst( $status ) ) . '</p>';
+		echo '<p class="wpam-type">' . esc_html( ucfirst( $type ) ) . '</p>';
+		echo '<p class="wpam-countdown" data-end="' . esc_attr( $end_ts ) . '"></p>';
+		echo '<p>' . esc_html__( 'Current Bid:', 'wpam' ) . ' <span class="wpam-current-bid" data-auction-id="' . esc_attr( $auction_id ) . '">' . esc_html( $display_highest ) . '</span></p>';
+	}
 
-    public function render_bid_form() {
-        global $product;
-        echo '<form class="wpam-bid-form">';
-        echo '<input type="number" step="0.01" class="wpam-bid-input" />';
-        wp_nonce_field( 'wpam_place_bid', 'wpam_bid_nonce', false );
-        echo '<button class="button wpam-bid-button" data-auction-id="' . esc_attr( $product->get_id() ) . '">' . esc_html__( 'Place Bid', 'wpam' ) . '</button>';
-        echo '</form>';
-    }
+	public function render_bid_form() {
+		global $product;
+		echo '<form class="wpam-bid-form">';
+		echo '<input type="number" step="0.01" class="wpam-bid-input" />';
+		wp_nonce_field( 'wpam_place_bid', 'wpam_bid_nonce', false );
+		echo '<button class="button wpam-bid-button" data-auction-id="' . esc_attr( $product->get_id() ) . '">' . esc_html__( 'Place Bid', 'wpam' ) . '</button>';
+		echo '</form>';
+	}
 
-    public function render_watchlist_button() {
-        global $product;
-        wp_nonce_field( 'wpam_toggle_watchlist', 'wpam_watchlist_nonce', false );
-        echo '<button class="button wpam-watchlist-button" data-auction-id="' . esc_attr( $product->get_id() ) . '">' . esc_html__( 'Toggle Watchlist', 'wpam' ) . '</button>';
-    }
+	public function render_watchlist_button() {
+		global $product;
+		wp_nonce_field( 'wpam_toggle_watchlist', 'wpam_watchlist_nonce', false );
+		echo '<button class="button wpam-watchlist-button" data-auction-id="' . esc_attr( $product->get_id() ) . '">' . esc_html__( 'Toggle Watchlist', 'wpam' ) . '</button>';
+	}
 
-    public function render_messages() {
-        global $product;
-        echo '<div class="wpam-messages">';
-        echo '<h2>' . esc_html__( 'Questions & Answers', 'wpam' ) . '</h2>';
-        echo '<div class="wpam-messages-list"></div>';
-        if ( is_user_logged_in() ) {
-            echo '<textarea class="wpam-message-input" rows="3"></textarea>';
-            wp_nonce_field( 'wpam_submit_question', 'wpam_message_nonce', false );
-            echo '<button class="wpam-message-button" data-auction-id="' . esc_attr( $product->get_id() ) . '">' . esc_html__( 'Submit Question', 'wpam' ) . '</button>';
-        } else {
-            echo '<p>' . esc_html__( 'Please login to ask a question.', 'wpam' ) . '</p>';
-        }
-        echo '</div>';
-    }
+	public function render_messages() {
+		global $product;
+		echo '<div class="wpam-messages">';
+		echo '<h2>' . esc_html__( 'Questions & Answers', 'wpam' ) . '</h2>';
+		echo '<div class="wpam-messages-list"></div>';
+		if ( is_user_logged_in() ) {
+			echo '<textarea class="wpam-message-input" rows="3"></textarea>';
+			wp_nonce_field( 'wpam_submit_question', 'wpam_message_nonce', false );
+			echo '<button class="wpam-message-button" data-auction-id="' . esc_attr( $product->get_id() ) . '">' . esc_html__( 'Submit Question', 'wpam' ) . '</button>';
+		} else {
+			echo '<p>' . esc_html__( 'Please login to ask a question.', 'wpam' ) . '</p>';
+		}
+		echo '</div>';
+	}
 }


### PR DESCRIPTION
## Summary
- define constants for auction states
- persist auction state and ending reasons in cron jobs
- expose new fields via admin tables and REST

## Testing
- `vendor/bin/phpcs -d memory_limit=512M --standard=phpcs.xml includes/class-wpam-auction-state.php admin/class-wpam-auctions-table.php includes/class-wpam-auction.php public/class-wpam-public.php`
- `vendor/bin/phpunit tests` *(fails: `Class "PHPUnit\TextUI\Command" not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688a01dae52483338562c11584ca3cae