### PR TITLE
Fix timezone handling

### DIFF
--- a/admin/class-wpam-auctions-table.php
+++ b/admin/class-wpam-auctions-table.php
@@ -26,7 +26,7 @@ class WPAM_Auctions_Table extends \WP_List_Table {
 			),
 			'meta_query'     => array(),
 		);
-		$now                = current_time( 'mysql' );
+               $now                = wp_date( 'Y-m-d H:i:s', current_datetime()->getTimestamp(), wp_timezone() );
 		if ( $this->auction_type ) {
 			$args['meta_query'][] = array(
 				'key'   => '_auction_type',

--- a/public/class-wpam-public.php
+++ b/public/class-wpam-public.php
@@ -130,11 +130,15 @@ class WPAM_Public {
 	public function render_auction_meta() {
 		global $product;
 		$auction_id = $product->get_id();
-		$end        = get_post_meta( $auction_id, '_auction_end', true );
-		$end_ts     = $end ? strtotime( $end ) : 0;
+               $end        = get_post_meta( $auction_id, '_auction_end', true );
+               $end_ts     = 0;
+               if ( $end ) {
+                       $date   = new \DateTimeImmutable( $end, wp_timezone() );
+                       $end_ts = $date->getTimestamp();
+               }
 		$type       = get_post_meta( $auction_id, '_auction_type', true );
 		$status     = get_post_meta( $auction_id, '_auction_state', true );
-		$now        = current_time( 'timestamp' );
+               $now        = current_datetime()->getTimestamp();
 
 		global $wpdb;
 		$highest = $wpdb->get_var( $wpdb->prepare( "SELECT MAX(bid_amount) FROM {$wpdb->prefix}wc_auction_bids WHERE auction_id = %d", $auction_id ) );


### PR DESCRIPTION
## Summary
- use `wp_date()` and `current_datetime()` when querying auctions
- keep frontend metadata comparisons in site timezone

## Testing
- `php -l admin/class-wpam-auctions-table.php`
- `php -l public/class-wpam-public.php`
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Error establishing a database connection)*
- `vendor/bin/phpcs -d memory_limit=512M -p --standard=phpcs.xml .` *(terminated due to memory usage)*

------
https://chatgpt.com/codex/tasks/task_e_688a0826b0608333908eac2a741ef102