### PR TITLE
Add admin action logs

### DIFF
--- a/admin/class-wpam-admin.php
+++ b/admin/class-wpam-admin.php
@@ -2,530 +2,550 @@
 namespace WPAM\Admin;
 
 class WPAM_Admin {
-    public function __construct() {
-        add_action( 'admin_menu', [ $this, 'add_menu' ] );
-        add_action( 'admin_init', [ $this, 'register_settings' ] );
-        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
-        add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );
-    }
-
-    public function add_menu() {
-        add_menu_page(
-            __( 'Auctions', 'wpam' ),
-            __( 'Auctions', 'wpam' ),
-            'manage_options',
-            'wpam-auctions',
-            [ $this, 'render_auctions_page' ],
-            'dashicons-hammer',
-            56
-        );
-
-        add_submenu_page(
-            'wpam-auctions',
-            __( 'All Auctions', 'wpam' ),
-            __( 'All Auctions', 'wpam' ),
-            'manage_options',
-            'wpam-auctions',
-            [ $this, 'render_auctions_page' ]
-        );
-
-        add_submenu_page(
-            'wpam-auctions',
-            __( 'Bids', 'wpam' ),
-            __( 'Bids', 'wpam' ),
-            'manage_options',
-            'wpam-bids',
-            [ $this, 'render_bids_page' ]
-        );
-
-        add_submenu_page(
-            'wpam-auctions',
-            __( 'Messages', 'wpam' ),
-            __( 'Messages', 'wpam' ),
-            'manage_options',
-            'wpam-messages',
-            [ $this, 'render_messages_page' ]
-        );
-
-        add_submenu_page(
-            'wpam-auctions',
-            __( 'Integrations', 'wpam' ),
-            __( 'Settings', 'wpam' ),
-            'manage_options',
-            'wpam-settings',
-            [ $this, 'render_settings_page' ]
-        );
-    }
-
-    public function register_settings() {
-        register_setting( 'wpam_settings', 'wpam_default_increment' );
-        register_setting( 'wpam_settings', 'wpam_soft_close' );
-        register_setting( 'wpam_settings', 'wpam_enable_twilio' );
-        register_setting( 'wpam_settings', 'wpam_enable_firebase' );
-        register_setting( 'wpam_settings', 'wpam_firebase_server_key' );
-        register_setting( 'wpam_settings', 'wpam_sendgrid_key' );
-        register_setting( 'wpam_settings', 'wpam_require_kyc' );
-        register_setting( 'wpam_settings', 'wpam_twilio_sid' );
-        register_setting( 'wpam_settings', 'wpam_twilio_token' );
-        register_setting( 'wpam_settings', 'wpam_twilio_from' );
-
-        register_setting( 'wpam_settings', 'wpam_pusher_app_id' );
-        register_setting( 'wpam_settings', 'wpam_pusher_key' );
-        register_setting( 'wpam_settings', 'wpam_pusher_secret' );
-        register_setting( 'wpam_settings', 'wpam_pusher_cluster' );
-        register_setting( 'wpam_settings', 'wpam_soft_close_threshold' );
-        register_setting( 'wpam_settings', 'wpam_soft_close_extend' );
-        register_setting( 'wpam_settings', 'wpam_realtime_provider' );
-
-        register_setting( 'wpam_settings', 'wpam_default_auction_type' );
-        register_setting( 'wpam_settings', 'wpam_enable_proxy_bidding' );
-        register_setting( 'wpam_settings', 'wpam_enable_silent_bidding' );
-        register_setting( 'wpam_settings', 'wpam_buyer_premium' );
-        register_setting( 'wpam_settings', 'wpam_seller_fee' );
-
-        add_settings_section( 'wpam_general', __( 'Auction Defaults', 'wpam' ), '__return_false', 'wpam_settings' );
-        add_settings_section( 'wpam_providers', __( 'Providers', 'wpam' ), '__return_false', 'wpam_settings' );      
-        add_settings_section( 'wpam_twilio', __( 'Twilio Integration', 'wpam' ), '__return_false', 'wpam_settings' );
-        add_settings_section( 'wpam_firebase', __( 'Firebase Integration', 'wpam' ), '__return_false', 'wpam_settings' );
-        add_settings_section( 'wpam_realtime', __( 'Realtime Integration', 'wpam' ), '__return_false', 'wpam_settings' );
-
-        add_settings_section( 'wpam_pusher', __( 'Pusher Realtime', 'wpam' ), '__return_false', 'wpam_settings' );
-
-        add_settings_field(
-            'wpam_soft_close_threshold',
-            __( 'Soft Close Threshold (seconds)', 'wpam' ),
-            [ $this, 'field_soft_close_threshold' ],
-            'wpam_settings',
-            'wpam_general'
-        );
-
-        add_settings_field(
-            'wpam_soft_close_extend',
-            __( 'Extension Duration (seconds)', 'wpam' ),
-            [ $this, 'field_soft_close_extend' ],
-            'wpam_settings',
-            'wpam_general'
-        );
-
-        add_settings_field(
-            'wpam_default_increment',
-            __( 'Default Bid Increment', 'wpam' ),
-            [ $this, 'field_default_increment' ],
-            'wpam_settings',
-            'wpam_general'
-        );
-
-        add_settings_field(
-            'wpam_soft_close',
-            __( 'Soft Close Duration (minutes)', 'wpam' ),
-            [ $this, 'field_soft_close' ],
-            'wpam_settings',
-            'wpam_general'
-        );
-
-        add_settings_field(
-            'wpam_enable_twilio',
-            __( 'Enable Twilio Notifications', 'wpam' ),
-            [ $this, 'field_enable_twilio' ],
-            'wpam_settings',
-            'wpam_providers'
-        );
-
-
-        add_settings_field(
-            'wpam_enable_firebase',
-            __( 'Enable Firebase', 'wpam' ),
-            [ $this, 'field_enable_firebase' ],
-            'wpam_settings',
-            'wpam_providers'
-        );
-
-        add_settings_field(
-            'wpam_firebase_server_key',
-            __( 'Firebase Server Key', 'wpam' ),
-            [ $this, 'field_firebase_server_key' ],
-            'wpam_settings',
-            'wpam_firebase'
-        );
-
-        add_settings_field(
-            'wpam_twilio_sid',
-            __( 'Twilio SID', 'wpam' ),
-            [ $this, 'field_twilio_sid' ],
-            'wpam_settings',
-            'wpam_twilio'
-        );
-
-        add_settings_field(
-            'wpam_twilio_token',
-            __( 'Twilio Token', 'wpam' ),
-            [ $this, 'field_twilio_token' ],
-            'wpam_settings',
-            'wpam_twilio'
-        );
-
-        add_settings_field(
-            'wpam_twilio_from',
-            __( 'Twilio From Number', 'wpam' ),
-            [ $this, 'field_twilio_from' ],
-            'wpam_settings',
-            'wpam_twilio'
-        );
-
-        add_settings_field(
-            'wpam_sendgrid_key',
-            __( 'SendGrid API Key', 'wpam' ),
-            [ $this, 'field_sendgrid_key' ],
-            'wpam_settings',
-            'wpam_providers'
-        );
-
-        add_settings_field(
-            'wpam_require_kyc',
-            __( 'Require KYC Verification', 'wpam' ),
-            [ $this, 'field_require_kyc' ],
-            'wpam_settings',
-            'wpam_general'
-        );
-
-        add_settings_field(
-            'wpam_realtime_provider',
-            __( 'Realtime Provider', 'wpam' ),
-            [ $this, 'field_realtime_provider' ],
-            'wpam_settings',
-            'wpam_realtime'
-        );
-
-        add_settings_field(
-            'wpam_pusher_app_id',
-            __( 'Pusher App ID', 'wpam' ),
-            [ $this, 'field_pusher_app_id' ],
-            'wpam_settings',
-            'wpam_realtime'
-        );
-
-        add_settings_field(
-            'wpam_pusher_key',
-            __( 'Pusher Key', 'wpam' ),
-            [ $this, 'field_pusher_key' ],
-            'wpam_settings',
-            'wpam_realtime'
-        );
-
-        add_settings_field(
-            'wpam_pusher_secret',
-            __( 'Pusher Secret', 'wpam' ),
-            [ $this, 'field_pusher_secret' ],
-            'wpam_settings',
-            'wpam_realtime'
-        );
-
-        add_settings_field(
-            'wpam_pusher_cluster',
-            __( 'Pusher Cluster', 'wpam' ),
-            [ $this, 'field_pusher_cluster' ],
-            'wpam_settings',
-            'wpam_realtime'
-        );
-    }
-
-    public function field_twilio_sid() {
-        $value = esc_attr( get_option( 'wpam_twilio_sid', '' ) );
-        echo '<input type="text" class="regular-text" name="wpam_twilio_sid" value="' . $value . '" />';
-    }
-
-    public function field_twilio_token() {
-        $value = esc_attr( get_option( 'wpam_twilio_token', '' ) );
-        echo '<input type="text" class="regular-text" name="wpam_twilio_token" value="' . $value . '" />';
-    }
-
-    public function field_twilio_from() {
-        $value = esc_attr( get_option( 'wpam_twilio_from', '' ) );
-        echo '<input type="text" class="regular-text" name="wpam_twilio_from" value="' . $value . '" />';
-    }
-
-
-    public function field_pusher_app_id() {
-        $value = esc_attr( get_option( 'wpam_pusher_app_id', '' ) );
-        echo '<input type="text" class="regular-text" name="wpam_pusher_app_id" value="' . $value . '" />';
-    }
-
-    public function field_pusher_key() {
-        $value = esc_attr( get_option( 'wpam_pusher_key', '' ) );
-        echo '<input type="text" class="regular-text" name="wpam_pusher_key" value="' . $value . '" />';
-    }
-
-    public function field_pusher_secret() {
-        $value = esc_attr( get_option( 'wpam_pusher_secret', '' ) );
-        echo '<input type="text" class="regular-text" name="wpam_pusher_secret" value="' . $value . '" />';
-    }
-
-    public function field_pusher_cluster() {
-        $value = esc_attr( get_option( 'wpam_pusher_cluster', '' ) );
-        echo '<input type="text" class="regular-text" name="wpam_pusher_cluster" value="' . $value . '" />';
-    }
-  
-    public function field_soft_close_threshold() {
-        $value = esc_attr( get_option( 'wpam_soft_close_threshold', 30 ) );
-        echo '<input type="number" class="small-text" name="wpam_soft_close_threshold" value="' . $value . '" />';
-    }
-
-    public function field_soft_close_extend() {
-        $value = esc_attr( get_option( 'wpam_soft_close_extend', 30 ) );
-        echo '<input type="number" class="small-text" name="wpam_soft_close_extend" value="' . $value . '" />';
-    }
-
-    public function field_default_increment() {
-        $value = esc_attr( get_option( 'wpam_default_increment', 1 ) );
-        echo '<input type="number" step="0.01" class="small-text" name="wpam_default_increment" value="' . $value . '" />';
-    }
-
-    public function field_soft_close() {
-        $value = esc_attr( get_option( 'wpam_soft_close', 0 ) );
-        echo '<input type="number" class="small-text" name="wpam_soft_close" value="' . $value . '" />';
-    }
-
-    public function field_enable_twilio() {
-        $value = get_option( 'wpam_enable_twilio', false );
-        echo '<input type="checkbox" name="wpam_enable_twilio" value="1"' . checked( 1, $value, false ) . ' />';
-    }
-
-    public function field_enable_firebase() {
-        $value = get_option( 'wpam_enable_firebase', false );
-        echo '<input type="checkbox" name="wpam_enable_firebase" value="1"' . checked( 1, $value, false ) . ' />';
-    }
-
-    public function field_firebase_server_key() {
-        $value = esc_attr( get_option( 'wpam_firebase_server_key', '' ) );
-        echo '<input type="text" class="regular-text" name="wpam_firebase_server_key" value="' . $value . '" />';
-    }
-
-    public function field_sendgrid_key() {
-        $value = esc_attr( get_option( 'wpam_sendgrid_key', '' ) );
-        echo '<input type="text" class="regular-text" name="wpam_sendgrid_key" value="' . $value . '" />';
-    }
-
-    public function field_require_kyc() {
-        $value = get_option( 'wpam_require_kyc', false );
-        echo '<input type="checkbox" name="wpam_require_kyc" value="1"' . checked( 1, $value, false ) . ' />';
-    }
-
-    public function field_realtime_provider() {
-        $value = esc_attr( get_option( 'wpam_realtime_provider', 'none' ) );
-        echo '<select name="wpam_realtime_provider">';
-        echo '<option value="none"' . selected( $value, 'none', false ) . '>' . esc_html__( 'None', 'wpam' ) . '</option>';
-        echo '<option value="pusher"' . selected( $value, 'pusher', false ) . '>' . esc_html__( 'Pusher', 'wpam' ) . '</option>';
-        echo '</select>';
-    }
-
-    public function render_auctions_page() {
-        $table = new WPAM_Auctions_Table();
-        $table->prepare_items();
-        echo '<div class="wrap">';
-        echo '<h1>' . esc_html__( 'Auctions', 'wpam' ) . '</h1>';
-        echo '<form method="get">';
-        echo '<input type="hidden" name="page" value="wpam-auctions" />';
-        $table->views();
-        $table->search_box( __( 'Search Auctions', 'wpam' ), 'auction-search' );
-        $table->display();
-        echo '</form></div>';
-    }
-
-    public function render_bids_page() {
-        $auction_id = isset( $_GET['auction_id'] ) ? absint( $_GET['auction_id'] ) : 0;
-        echo '<div class="wrap">';
-        if ( ! $auction_id ) {
-            echo '<h1>' . esc_html__( 'Bids', 'wpam' ) . '</h1>';
-            echo '<p>' . esc_html__( 'No auction selected.', 'wpam' ) . '</p>';
-            echo '</div>';
-            return;
-        }
-        $table = new WPAM_Bids_Table( $auction_id );
-        $table->prepare_items();
-        echo '<h1>' . sprintf( esc_html__( 'Bids for Auction #%d', 'wpam' ), $auction_id ) . '</h1>';
-        echo '<form method="get">';
-        echo '<input type="hidden" name="page" value="wpam-bids" />';
-        echo '<input type="hidden" name="auction_id" value="' . esc_attr( $auction_id ) . '" />';
-        $table->display();
-        echo '</form></div>';
-    }
-
-    public function render_messages_page() {
-
-        if ( isset( $_GET['action'], $_GET['message'] ) && in_array( $_GET['action'], [ 'approve', 'unapprove' ], true ) ) {
-            $message_id = absint( $_GET['message'] );
-            check_admin_referer( 'wpam_toggle_message_' . $message_id );
-            global $wpdb;
-            $table = $wpdb->prefix . 'wc_auction_messages';
-            $approved = 'approve' === $_GET['action'] ? 1 : 0;
-            $wpdb->update( $table, [ 'approved' => $approved ], [ 'id' => $message_id ], [ '%d' ], [ '%d' ] );
-            echo '<div class="updated"><p>' . esc_html__( 'Message updated.', 'wpam' ) . '</p></div>';
-        }
-
-        $table = new WPAM_Messages_Table();
-        $table->prepare_items();
-        echo '<div class="wrap">';
-        echo '<h1>' . esc_html__( 'Auction Messages', 'wpam' ) . '</h1>';
-        echo '<form method="get">';
-        echo '<input type="hidden" name="page" value="wpam-messages" />';
-        $table->search_box( __( 'Search Messages', 'wpam' ), 'message-search' );
-        $table->display();
-        echo '</form></div>';
-    }
-
-    public function enqueue_scripts( $hook ) {
-        $screen = get_current_screen();
-
-        if ( 'post-new.php' === $hook && 'product' === $screen->post_type && 'add' === $screen->action ) {
-            wp_enqueue_script(
-                'wpam-select-auction-type',
-                WPAM_PLUGIN_URL . 'admin/js/select-auction-product-type.js',
-                [ 'jquery' ],
-                WPAM_PLUGIN_VERSION,
-                true
-            );
-        }
-
-        if ( in_array( $hook, [ 'post-new.php', 'post.php' ], true ) && 'product' === $screen->post_type ) {
-            wp_enqueue_style(
-                'flatpickr',
-                'https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css',
-                [],
-                '4.6.13'
-            );
-            wp_enqueue_script(
-                'flatpickr',
-                'https://cdn.jsdelivr.net/npm/flatpickr',
-                [],
-                '4.6.13',
-                true
-            );
-            wp_enqueue_script(
-                'wpam-date-picker',
-                WPAM_PLUGIN_URL . 'admin/js/auction-date-picker.js',
-                [ 'jquery', 'flatpickr' ],
-                WPAM_PLUGIN_VERSION,
-                true
-            );
-        }
-
-        $slug        = 'auctions';
-        $admin_pages = [
-            'toplevel_page_wpam-' . $slug,
-            $slug . '_page_wpam-auctions',
-            $slug . '_page_wpam-bids',
-            $slug . '_page_wpam-messages',
-            $slug . '_page_wpam-settings',
-        ];
-
-        if ( in_array( $hook, $admin_pages, true ) ) {
-            wp_enqueue_style(
-                'wpam-admin',
-                WPAM_PLUGIN_URL . 'admin/css/wpam-admin.css',
-                [ 'wp-components' ],
-                WPAM_PLUGIN_VERSION
-            );
-        }
-
-        if ( $slug . '_page_wpam-settings' !== $hook ) {
-            return;
-        }
-
-        wp_enqueue_script(
-            'wpam-settings-app',
-            WPAM_PLUGIN_URL . 'admin/js/settings-app.js',
-            [ 'wp-element', 'wp-components', 'wp-api-fetch' ],
-            WPAM_PLUGIN_VERSION,
-            true
-        );
-
-        wp_localize_script(
-            'wpam-settings-app',
-            'wpamSettings',
-            [
-                'nonce'    => wp_create_nonce( 'wp_rest' ),
-                'rest_endpoint' => 'wpam/v1/settings',
-            ]
-        );
-    }
-
-    public function register_rest_routes() {
-        register_rest_route(
-            'wpam/v1',
-            '/settings',
-            [
-                'methods'             => \WP_REST_Server::READABLE,
-                'callback'            => [ $this, 'rest_get_settings' ],
-                'permission_callback' => function() {
-                    return current_user_can( 'manage_options' );
-                },
-            ]
-        );
-
-        register_rest_route(
-            'wpam/v1',
-            '/settings',
-            [
-                'methods'             => \WP_REST_Server::EDITABLE,
-                'callback'            => [ $this, 'rest_update_settings' ],
-                'permission_callback' => function() {
-                    return current_user_can( 'manage_options' );
-                },
-            ]
-        );
-    }
-
-    public function rest_get_settings( \WP_REST_Request $request ) {
-        $options = [];
-        foreach ( $this->get_option_keys() as $key ) {
-            $options[ $key ] = get_option( $key );
-        }
-
-        return rest_ensure_response( $options );
-    }
-
-    public function rest_update_settings( \WP_REST_Request $request ) {
-        $params = $request->get_json_params();
-        foreach ( $this->get_option_keys() as $key ) {
-            if ( isset( $params[ $key ] ) ) {
-                update_option( $key, $params[ $key ] );
-            }
-        }
-
-        return $this->rest_get_settings( $request );
-    }
-
-    private function get_option_keys() {
-        return [
-            'wpam_default_increment',
-            'wpam_soft_close',
-            'wpam_enable_twilio',
-            'wpam_enable_firebase',
-            'wpam_firebase_server_key',
-            'wpam_sendgrid_key',
-            'wpam_twilio_sid',
-            'wpam_twilio_token',
-            'wpam_twilio_from',
-            'wpam_pusher_app_id',
-            'wpam_pusher_key',
-            'wpam_pusher_secret',
-            'wpam_pusher_cluster',
-            'wpam_soft_close_threshold',
-            'wpam_soft_close_extend',
-            'wpam_realtime_provider',
-            'wpam_require_kyc',
-            'wpam_default_auction_type',
-            'wpam_enable_proxy_bidding',
-            'wpam_enable_silent_bidding',
-            'wpam_buyer_premium',
-            'wpam_seller_fee',
-        ];
-    }
-
-    public function render_settings_page() {
-        echo '<div class="wrap">';
-        echo '<h1>' . esc_html__( 'Settings', 'wpam' ) . '</h1>';
-        echo '<div id="wpam-settings-root"></div>';
-        echo '</div>';
-    }
+	public function __construct() {
+		add_action( 'admin_menu', array( $this, 'add_menu' ) );
+		add_action( 'admin_init', array( $this, 'register_settings' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ) );
+	}
+
+	public function add_menu() {
+		add_menu_page(
+			__( 'Auctions', 'wpam' ),
+			__( 'Auctions', 'wpam' ),
+			'manage_options',
+			'wpam-auctions',
+			array( $this, 'render_auctions_page' ),
+			'dashicons-hammer',
+			56
+		);
+
+		add_submenu_page(
+			'wpam-auctions',
+			__( 'All Auctions', 'wpam' ),
+			__( 'All Auctions', 'wpam' ),
+			'manage_options',
+			'wpam-auctions',
+			array( $this, 'render_auctions_page' )
+		);
+
+		add_submenu_page(
+			'wpam-auctions',
+			__( 'Bids', 'wpam' ),
+			__( 'Bids', 'wpam' ),
+			'manage_options',
+			'wpam-bids',
+			array( $this, 'render_bids_page' )
+		);
+
+		add_submenu_page(
+			'wpam-auctions',
+			__( 'Messages', 'wpam' ),
+			__( 'Messages', 'wpam' ),
+			'manage_options',
+			'wpam-messages',
+			array( $this, 'render_messages_page' )
+		);
+
+		add_submenu_page(
+			'wpam-auctions',
+			__( 'Logs', 'wpam' ),
+			__( 'Logs', 'wpam' ),
+			'manage_options',
+			'wpam-logs',
+			array( $this, 'render_logs_page' )
+		);
+
+		add_submenu_page(
+			'wpam-auctions',
+			__( 'Integrations', 'wpam' ),
+			__( 'Settings', 'wpam' ),
+			'manage_options',
+			'wpam-settings',
+			array( $this, 'render_settings_page' )
+		);
+	}
+
+	public function register_settings() {
+		register_setting( 'wpam_settings', 'wpam_default_increment' );
+		register_setting( 'wpam_settings', 'wpam_soft_close' );
+		register_setting( 'wpam_settings', 'wpam_enable_twilio' );
+		register_setting( 'wpam_settings', 'wpam_enable_firebase' );
+		register_setting( 'wpam_settings', 'wpam_firebase_server_key' );
+		register_setting( 'wpam_settings', 'wpam_sendgrid_key' );
+		register_setting( 'wpam_settings', 'wpam_require_kyc' );
+		register_setting( 'wpam_settings', 'wpam_twilio_sid' );
+		register_setting( 'wpam_settings', 'wpam_twilio_token' );
+		register_setting( 'wpam_settings', 'wpam_twilio_from' );
+
+		register_setting( 'wpam_settings', 'wpam_pusher_app_id' );
+		register_setting( 'wpam_settings', 'wpam_pusher_key' );
+		register_setting( 'wpam_settings', 'wpam_pusher_secret' );
+		register_setting( 'wpam_settings', 'wpam_pusher_cluster' );
+		register_setting( 'wpam_settings', 'wpam_soft_close_threshold' );
+		register_setting( 'wpam_settings', 'wpam_soft_close_extend' );
+		register_setting( 'wpam_settings', 'wpam_realtime_provider' );
+
+		register_setting( 'wpam_settings', 'wpam_default_auction_type' );
+		register_setting( 'wpam_settings', 'wpam_enable_proxy_bidding' );
+		register_setting( 'wpam_settings', 'wpam_enable_silent_bidding' );
+		register_setting( 'wpam_settings', 'wpam_buyer_premium' );
+		register_setting( 'wpam_settings', 'wpam_seller_fee' );
+
+		add_settings_section( 'wpam_general', __( 'Auction Defaults', 'wpam' ), '__return_false', 'wpam_settings' );
+		add_settings_section( 'wpam_providers', __( 'Providers', 'wpam' ), '__return_false', 'wpam_settings' );
+		add_settings_section( 'wpam_twilio', __( 'Twilio Integration', 'wpam' ), '__return_false', 'wpam_settings' );
+		add_settings_section( 'wpam_firebase', __( 'Firebase Integration', 'wpam' ), '__return_false', 'wpam_settings' );
+		add_settings_section( 'wpam_realtime', __( 'Realtime Integration', 'wpam' ), '__return_false', 'wpam_settings' );
+
+		add_settings_section( 'wpam_pusher', __( 'Pusher Realtime', 'wpam' ), '__return_false', 'wpam_settings' );
+
+		add_settings_field(
+			'wpam_soft_close_threshold',
+			__( 'Soft Close Threshold (seconds)', 'wpam' ),
+			array( $this, 'field_soft_close_threshold' ),
+			'wpam_settings',
+			'wpam_general'
+		);
+
+		add_settings_field(
+			'wpam_soft_close_extend',
+			__( 'Extension Duration (seconds)', 'wpam' ),
+			array( $this, 'field_soft_close_extend' ),
+			'wpam_settings',
+			'wpam_general'
+		);
+
+		add_settings_field(
+			'wpam_default_increment',
+			__( 'Default Bid Increment', 'wpam' ),
+			array( $this, 'field_default_increment' ),
+			'wpam_settings',
+			'wpam_general'
+		);
+
+		add_settings_field(
+			'wpam_soft_close',
+			__( 'Soft Close Duration (minutes)', 'wpam' ),
+			array( $this, 'field_soft_close' ),
+			'wpam_settings',
+			'wpam_general'
+		);
+
+		add_settings_field(
+			'wpam_enable_twilio',
+			__( 'Enable Twilio Notifications', 'wpam' ),
+			array( $this, 'field_enable_twilio' ),
+			'wpam_settings',
+			'wpam_providers'
+		);
+
+		add_settings_field(
+			'wpam_enable_firebase',
+			__( 'Enable Firebase', 'wpam' ),
+			array( $this, 'field_enable_firebase' ),
+			'wpam_settings',
+			'wpam_providers'
+		);
+
+		add_settings_field(
+			'wpam_firebase_server_key',
+			__( 'Firebase Server Key', 'wpam' ),
+			array( $this, 'field_firebase_server_key' ),
+			'wpam_settings',
+			'wpam_firebase'
+		);
+
+		add_settings_field(
+			'wpam_twilio_sid',
+			__( 'Twilio SID', 'wpam' ),
+			array( $this, 'field_twilio_sid' ),
+			'wpam_settings',
+			'wpam_twilio'
+		);
+
+		add_settings_field(
+			'wpam_twilio_token',
+			__( 'Twilio Token', 'wpam' ),
+			array( $this, 'field_twilio_token' ),
+			'wpam_settings',
+			'wpam_twilio'
+		);
+
+		add_settings_field(
+			'wpam_twilio_from',
+			__( 'Twilio From Number', 'wpam' ),
+			array( $this, 'field_twilio_from' ),
+			'wpam_settings',
+			'wpam_twilio'
+		);
+
+		add_settings_field(
+			'wpam_sendgrid_key',
+			__( 'SendGrid API Key', 'wpam' ),
+			array( $this, 'field_sendgrid_key' ),
+			'wpam_settings',
+			'wpam_providers'
+		);
+
+		add_settings_field(
+			'wpam_require_kyc',
+			__( 'Require KYC Verification', 'wpam' ),
+			array( $this, 'field_require_kyc' ),
+			'wpam_settings',
+			'wpam_general'
+		);
+
+		add_settings_field(
+			'wpam_realtime_provider',
+			__( 'Realtime Provider', 'wpam' ),
+			array( $this, 'field_realtime_provider' ),
+			'wpam_settings',
+			'wpam_realtime'
+		);
+
+		add_settings_field(
+			'wpam_pusher_app_id',
+			__( 'Pusher App ID', 'wpam' ),
+			array( $this, 'field_pusher_app_id' ),
+			'wpam_settings',
+			'wpam_realtime'
+		);
+
+		add_settings_field(
+			'wpam_pusher_key',
+			__( 'Pusher Key', 'wpam' ),
+			array( $this, 'field_pusher_key' ),
+			'wpam_settings',
+			'wpam_realtime'
+		);
+
+		add_settings_field(
+			'wpam_pusher_secret',
+			__( 'Pusher Secret', 'wpam' ),
+			array( $this, 'field_pusher_secret' ),
+			'wpam_settings',
+			'wpam_realtime'
+		);
+
+		add_settings_field(
+			'wpam_pusher_cluster',
+			__( 'Pusher Cluster', 'wpam' ),
+			array( $this, 'field_pusher_cluster' ),
+			'wpam_settings',
+			'wpam_realtime'
+		);
+	}
+
+	public function field_twilio_sid() {
+		$value = esc_attr( get_option( 'wpam_twilio_sid', '' ) );
+		echo '<input type="text" class="regular-text" name="wpam_twilio_sid" value="' . $value . '" />';
+	}
+
+	public function field_twilio_token() {
+		$value = esc_attr( get_option( 'wpam_twilio_token', '' ) );
+		echo '<input type="text" class="regular-text" name="wpam_twilio_token" value="' . $value . '" />';
+	}
+
+	public function field_twilio_from() {
+		$value = esc_attr( get_option( 'wpam_twilio_from', '' ) );
+		echo '<input type="text" class="regular-text" name="wpam_twilio_from" value="' . $value . '" />';
+	}
+
+
+	public function field_pusher_app_id() {
+		$value = esc_attr( get_option( 'wpam_pusher_app_id', '' ) );
+		echo '<input type="text" class="regular-text" name="wpam_pusher_app_id" value="' . $value . '" />';
+	}
+
+	public function field_pusher_key() {
+		$value = esc_attr( get_option( 'wpam_pusher_key', '' ) );
+		echo '<input type="text" class="regular-text" name="wpam_pusher_key" value="' . $value . '" />';
+	}
+
+	public function field_pusher_secret() {
+		$value = esc_attr( get_option( 'wpam_pusher_secret', '' ) );
+		echo '<input type="text" class="regular-text" name="wpam_pusher_secret" value="' . $value . '" />';
+	}
+
+	public function field_pusher_cluster() {
+		$value = esc_attr( get_option( 'wpam_pusher_cluster', '' ) );
+		echo '<input type="text" class="regular-text" name="wpam_pusher_cluster" value="' . $value . '" />';
+	}
+
+	public function field_soft_close_threshold() {
+		$value = esc_attr( get_option( 'wpam_soft_close_threshold', 30 ) );
+		echo '<input type="number" class="small-text" name="wpam_soft_close_threshold" value="' . $value . '" />';
+	}
+
+	public function field_soft_close_extend() {
+		$value = esc_attr( get_option( 'wpam_soft_close_extend', 30 ) );
+		echo '<input type="number" class="small-text" name="wpam_soft_close_extend" value="' . $value . '" />';
+	}
+
+	public function field_default_increment() {
+		$value = esc_attr( get_option( 'wpam_default_increment', 1 ) );
+		echo '<input type="number" step="0.01" class="small-text" name="wpam_default_increment" value="' . $value . '" />';
+	}
+
+	public function field_soft_close() {
+		$value = esc_attr( get_option( 'wpam_soft_close', 0 ) );
+		echo '<input type="number" class="small-text" name="wpam_soft_close" value="' . $value . '" />';
+	}
+
+	public function field_enable_twilio() {
+		$value = get_option( 'wpam_enable_twilio', false );
+		echo '<input type="checkbox" name="wpam_enable_twilio" value="1"' . checked( 1, $value, false ) . ' />';
+	}
+
+	public function field_enable_firebase() {
+		$value = get_option( 'wpam_enable_firebase', false );
+		echo '<input type="checkbox" name="wpam_enable_firebase" value="1"' . checked( 1, $value, false ) . ' />';
+	}
+
+	public function field_firebase_server_key() {
+		$value = esc_attr( get_option( 'wpam_firebase_server_key', '' ) );
+		echo '<input type="text" class="regular-text" name="wpam_firebase_server_key" value="' . $value . '" />';
+	}
+
+	public function field_sendgrid_key() {
+		$value = esc_attr( get_option( 'wpam_sendgrid_key', '' ) );
+		echo '<input type="text" class="regular-text" name="wpam_sendgrid_key" value="' . $value . '" />';
+	}
+
+	public function field_require_kyc() {
+		$value = get_option( 'wpam_require_kyc', false );
+		echo '<input type="checkbox" name="wpam_require_kyc" value="1"' . checked( 1, $value, false ) . ' />';
+	}
+
+	public function field_realtime_provider() {
+		$value = esc_attr( get_option( 'wpam_realtime_provider', 'none' ) );
+		echo '<select name="wpam_realtime_provider">';
+		echo '<option value="none"' . selected( $value, 'none', false ) . '>' . esc_html__( 'None', 'wpam' ) . '</option>';
+		echo '<option value="pusher"' . selected( $value, 'pusher', false ) . '>' . esc_html__( 'Pusher', 'wpam' ) . '</option>';
+		echo '</select>';
+	}
+
+	public function render_auctions_page() {
+		$table = new WPAM_Auctions_Table();
+		$table->prepare_items();
+		echo '<div class="wrap">';
+		echo '<h1>' . esc_html__( 'Auctions', 'wpam' ) . '</h1>';
+		echo '<form method="get">';
+		echo '<input type="hidden" name="page" value="wpam-auctions" />';
+		$table->views();
+		$table->search_box( __( 'Search Auctions', 'wpam' ), 'auction-search' );
+		$table->display();
+		echo '</form></div>';
+	}
+
+	public function render_bids_page() {
+		$auction_id = isset( $_GET['auction_id'] ) ? absint( $_GET['auction_id'] ) : 0;
+		echo '<div class="wrap">';
+		if ( ! $auction_id ) {
+			echo '<h1>' . esc_html__( 'Bids', 'wpam' ) . '</h1>';
+			echo '<p>' . esc_html__( 'No auction selected.', 'wpam' ) . '</p>';
+			echo '</div>';
+			return;
+		}
+		$table = new WPAM_Bids_Table( $auction_id );
+		$table->prepare_items();
+		echo '<h1>' . sprintf( esc_html__( 'Bids for Auction #%d', 'wpam' ), $auction_id ) . '</h1>';
+		echo '<form method="get">';
+		echo '<input type="hidden" name="page" value="wpam-bids" />';
+		echo '<input type="hidden" name="auction_id" value="' . esc_attr( $auction_id ) . '" />';
+		$table->display();
+		echo '</form></div>';
+	}
+
+	public function render_messages_page() {
+
+		if ( isset( $_GET['action'], $_GET['message'] ) && in_array( $_GET['action'], array( 'approve', 'unapprove' ), true ) ) {
+			$message_id = absint( $_GET['message'] );
+			check_admin_referer( 'wpam_toggle_message_' . $message_id );
+			global $wpdb;
+			$table    = $wpdb->prefix . 'wc_auction_messages';
+			$approved = 'approve' === $_GET['action'] ? 1 : 0;
+			$wpdb->update( $table, array( 'approved' => $approved ), array( 'id' => $message_id ), array( '%d' ), array( '%d' ) );
+			echo '<div class="updated"><p>' . esc_html__( 'Message updated.', 'wpam' ) . '</p></div>';
+		}
+
+		$table = new WPAM_Messages_Table();
+		$table->prepare_items();
+		echo '<div class="wrap">';
+		echo '<h1>' . esc_html__( 'Auction Messages', 'wpam' ) . '</h1>';
+		echo '<form method="get">';
+		echo '<input type="hidden" name="page" value="wpam-messages" />';
+		$table->search_box( __( 'Search Messages', 'wpam' ), 'message-search' );
+		$table->display();
+		echo '</form></div>';
+	}
+
+	public function render_logs_page() {
+		$table = new WPAM_Logs_Table();
+		$table->prepare_items();
+		echo '<div class="wrap">';
+		echo '<h1>' . esc_html__( 'Admin Logs', 'wpam' ) . '</h1>';
+		echo '<form method="get">';
+		echo '<input type="hidden" name="page" value="wpam-logs" />';
+		$table->display();
+		echo '</form></div>';
+	}
+
+	public function enqueue_scripts( $hook ) {
+		$screen = get_current_screen();
+
+		if ( 'post-new.php' === $hook && 'product' === $screen->post_type && 'add' === $screen->action ) {
+			wp_enqueue_script(
+				'wpam-select-auction-type',
+				WPAM_PLUGIN_URL . 'admin/js/select-auction-product-type.js',
+				array( 'jquery' ),
+				WPAM_PLUGIN_VERSION,
+				true
+			);
+		}
+
+		if ( in_array( $hook, array( 'post-new.php', 'post.php' ), true ) && 'product' === $screen->post_type ) {
+			wp_enqueue_style(
+				'flatpickr',
+				'https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css',
+				array(),
+				'4.6.13'
+			);
+			wp_enqueue_script(
+				'flatpickr',
+				'https://cdn.jsdelivr.net/npm/flatpickr',
+				array(),
+				'4.6.13',
+				true
+			);
+			wp_enqueue_script(
+				'wpam-date-picker',
+				WPAM_PLUGIN_URL . 'admin/js/auction-date-picker.js',
+				array( 'jquery', 'flatpickr' ),
+				WPAM_PLUGIN_VERSION,
+				true
+			);
+		}
+
+		$slug        = 'auctions';
+		$admin_pages = array(
+			'toplevel_page_wpam-' . $slug,
+			$slug . '_page_wpam-auctions',
+			$slug . '_page_wpam-bids',
+			$slug . '_page_wpam-messages',
+			$slug . '_page_wpam-logs',
+			$slug . '_page_wpam-settings',
+		);
+
+		if ( in_array( $hook, $admin_pages, true ) ) {
+			wp_enqueue_style(
+				'wpam-admin',
+				WPAM_PLUGIN_URL . 'admin/css/wpam-admin.css',
+				array( 'wp-components' ),
+				WPAM_PLUGIN_VERSION
+			);
+		}
+
+		if ( $slug . '_page_wpam-settings' !== $hook ) {
+			return;
+		}
+
+		wp_enqueue_script(
+			'wpam-settings-app',
+			WPAM_PLUGIN_URL . 'admin/js/settings-app.js',
+			array( 'wp-element', 'wp-components', 'wp-api-fetch' ),
+			WPAM_PLUGIN_VERSION,
+			true
+		);
+
+		wp_localize_script(
+			'wpam-settings-app',
+			'wpamSettings',
+			array(
+				'nonce'         => wp_create_nonce( 'wp_rest' ),
+				'rest_endpoint' => 'wpam/v1/settings',
+			)
+		);
+	}
+
+	public function register_rest_routes() {
+		register_rest_route(
+			'wpam/v1',
+			'/settings',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'rest_get_settings' ),
+				'permission_callback' => function () {
+					return current_user_can( 'manage_options' );
+				},
+			)
+		);
+
+		register_rest_route(
+			'wpam/v1',
+			'/settings',
+			array(
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'rest_update_settings' ),
+				'permission_callback' => function () {
+					return current_user_can( 'manage_options' );
+				},
+			)
+		);
+	}
+
+	public function rest_get_settings( \WP_REST_Request $request ) {
+		$options = array();
+		foreach ( $this->get_option_keys() as $key ) {
+			$options[ $key ] = get_option( $key );
+		}
+
+		return rest_ensure_response( $options );
+	}
+
+	public function rest_update_settings( \WP_REST_Request $request ) {
+		$params = $request->get_json_params();
+		foreach ( $this->get_option_keys() as $key ) {
+			if ( isset( $params[ $key ] ) ) {
+				update_option( $key, $params[ $key ] );
+			}
+		}
+
+		return $this->rest_get_settings( $request );
+	}
+
+	private function get_option_keys() {
+		return array(
+			'wpam_default_increment',
+			'wpam_soft_close',
+			'wpam_enable_twilio',
+			'wpam_enable_firebase',
+			'wpam_firebase_server_key',
+			'wpam_sendgrid_key',
+			'wpam_twilio_sid',
+			'wpam_twilio_token',
+			'wpam_twilio_from',
+			'wpam_pusher_app_id',
+			'wpam_pusher_key',
+			'wpam_pusher_secret',
+			'wpam_pusher_cluster',
+			'wpam_soft_close_threshold',
+			'wpam_soft_close_extend',
+			'wpam_realtime_provider',
+			'wpam_require_kyc',
+			'wpam_default_auction_type',
+			'wpam_enable_proxy_bidding',
+			'wpam_enable_silent_bidding',
+			'wpam_buyer_premium',
+			'wpam_seller_fee',
+		);
+	}
+
+	public function render_settings_page() {
+		echo '<div class="wrap">';
+		echo '<h1>' . esc_html__( 'Settings', 'wpam' ) . '</h1>';
+		echo '<div id="wpam-settings-root"></div>';
+		echo '</div>';
+	}
 }

--- a/admin/class-wpam-logs-table.php
+++ b/admin/class-wpam-logs-table.php
@@ -1,0 +1,58 @@
+<?php
+namespace WPAM\Admin;
+
+if ( ! class_exists( 'WP_List_Table' ) ) {
+	require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+}
+
+class WPAM_Logs_Table extends \WP_List_Table {
+	public function prepare_items() {
+		global $wpdb;
+		$table       = $wpdb->prefix . 'wc_auction_logs';
+		$results     = $wpdb->get_results( "SELECT * FROM $table ORDER BY logged_at DESC", ARRAY_A );
+		$this->items = $results;
+		$this->set_pagination_args(
+			array(
+				'total_items' => count( $results ),
+				'per_page'    => 50,
+				'total_pages' => 1,
+			)
+		);
+	}
+
+	public function get_columns() {
+		return array(
+			'auction' => __( 'Auction', 'wpam' ),
+			'admin'   => __( 'Admin', 'wpam' ),
+			'action'  => __( 'Action', 'wpam' ),
+			'details' => __( 'Details', 'wpam' ),
+			'date'    => __( 'Date', 'wpam' ),
+		);
+	}
+
+	protected function column_auction( $item ) {
+		$title = get_the_title( $item['auction_id'] );
+		return $title ? esc_html( $title ) : sprintf( '#%d', $item['auction_id'] );
+	}
+
+	protected function column_admin( $item ) {
+		$user = get_user_by( 'id', $item['admin_id'] );
+		return $user ? esc_html( $user->display_name ) : sprintf( '#%d', $item['admin_id'] );
+	}
+
+	protected function column_details( $item ) {
+		$details = maybe_unserialize( $item['details'] );
+		if ( is_array( $details ) ) {
+			$details = wp_json_encode( $details );
+		}
+		return esc_html( (string) $details );
+	}
+
+	protected function column_default( $item, $column_name ) {
+		return isset( $item[ $column_name ] ) ? esc_html( $item[ $column_name ] ) : '';
+	}
+
+	public function no_items() {
+		_e( 'No logs found.', 'wpam' );
+	}
+}

--- a/includes/class-wpam-admin-log.php
+++ b/includes/class-wpam-admin-log.php
@@ -1,0 +1,42 @@
+<?php
+namespace WPAM\Includes;
+
+class WPAM_Admin_Log {
+	const ACTION_SUSPEND    = 'suspend';
+	const ACTION_CANCEL     = 'cancel';
+	const ACTION_PRICE_EDIT = 'price_edit';
+
+	public static function log_suspend( $auction_id ) {
+		self::insert_log( $auction_id, self::ACTION_SUSPEND );
+	}
+
+	public static function log_cancel( $auction_id ) {
+		self::insert_log( $auction_id, self::ACTION_CANCEL );
+	}
+
+	public static function log_price_edit( $auction_id, $old_price, $new_price ) {
+		$details = wp_json_encode(
+			array(
+				'old_price' => $old_price,
+				'new_price' => $new_price,
+			)
+		);
+		self::insert_log( $auction_id, self::ACTION_PRICE_EDIT, $details );
+	}
+
+	protected static function insert_log( $auction_id, $action, $details = '' ) {
+		global $wpdb;
+		$table = $wpdb->prefix . 'wc_auction_logs';
+		$wpdb->insert(
+			$table,
+			array(
+				'auction_id' => absint( $auction_id ),
+				'admin_id'   => get_current_user_id(),
+				'action'     => $action,
+				'details'    => maybe_serialize( $details ),
+				'logged_at'  => wp_date( 'Y-m-d H:i:s', null, wp_timezone() ),
+			),
+			array( '%d', '%d', '%s', '%s', '%s' )
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- track admin actions via new WPAM_Admin_Log class
- store admin logs with table in WPAM_Install
- list admin logs in new submenu using WPAM_Logs_Table

## Testing
- `composer dump-autoload`
- `vendor/bin/phpunit` *(fails: PHPUnit classes missing)*
- `vendor/bin/phpcs includes/class-wpam-admin-log.php admin/class-wpam-logs-table.php admin/class-wpam-admin.php includes/class-wpam-install.php -d memory_limit=512M`

------
https://chatgpt.com/codex/tasks/task_e_688a11661024833389b371094c23eb07