### PR TITLE
Add fraud detection feature

### DIFF
--- a/admin/class-wpam-admin.php
+++ b/admin/class-wpam-admin.php
@@ -47,14 +47,23 @@ class WPAM_Admin {
 			array( $this, 'render_messages_page' )
 		);
 
-		add_submenu_page(
-			'wpam-auctions',
-			__( 'Logs', 'wpam' ),
-			__( 'Logs', 'wpam' ),
-			'manage_options',
-			'wpam-logs',
-			array( $this, 'render_logs_page' )
-		);
+                add_submenu_page(
+                        'wpam-auctions',
+                        __( 'Logs', 'wpam' ),
+                        __( 'Logs', 'wpam' ),
+                        'manage_options',
+                        'wpam-logs',
+                        array( $this, 'render_logs_page' )
+                );
+
+                add_submenu_page(
+                        'wpam-auctions',
+                        __( 'Flagged Users', 'wpam' ),
+                        __( 'Flagged Users', 'wpam' ),
+                        'manage_options',
+                        'wpam-flagged',
+                        array( $this, 'render_flagged_page' )
+                );
 
 		add_submenu_page(
 			'wpam-auctions',
@@ -396,16 +405,27 @@ class WPAM_Admin {
 		echo '</form></div>';
 	}
 
-	public function render_logs_page() {
-		$table = new WPAM_Logs_Table();
-		$table->prepare_items();
-		echo '<div class="wrap">';
-		echo '<h1>' . esc_html__( 'Admin Logs', 'wpam' ) . '</h1>';
-		echo '<form method="get">';
-		echo '<input type="hidden" name="page" value="wpam-logs" />';
-		$table->display();
-		echo '</form></div>';
-	}
+        public function render_logs_page() {
+                $table = new WPAM_Logs_Table();
+                $table->prepare_items();
+                echo '<div class="wrap">';
+                echo '<h1>' . esc_html__( 'Admin Logs', 'wpam' ) . '</h1>';
+                echo '<form method="get">';
+                echo '<input type="hidden" name="page" value="wpam-logs" />';
+                $table->display();
+                echo '</form></div>';
+        }
+
+        public function render_flagged_page() {
+                $table = new WPAM_Flagged_Table();
+                $table->prepare_items();
+                echo '<div class="wrap">';
+                echo '<h1>' . esc_html__( 'Flagged Users', 'wpam' ) . '</h1>';
+                echo '<form method="get">';
+                echo '<input type="hidden" name="page" value="wpam-flagged" />';
+                $table->display();
+                echo '</form></div>';
+        }
 
 	public function enqueue_scripts( $hook ) {
 		$screen = get_current_screen();

--- a/admin/class-wpam-flagged-table.php
+++ b/admin/class-wpam-flagged-table.php
@@ -1,0 +1,41 @@
+<?php
+namespace WPAM\Admin;
+
+if ( ! class_exists( 'WP_List_Table' ) ) {
+    require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+}
+
+class WPAM_Flagged_Table extends \WP_List_Table {
+    public function prepare_items() {
+        global $wpdb;
+        $table       = $wpdb->prefix . 'wpam_flagged_users';
+        $results     = $wpdb->get_results( "SELECT * FROM $table ORDER BY flagged_at DESC", ARRAY_A );
+        $this->items = $results;
+        $this->set_pagination_args([
+            'total_items' => count( $results ),
+            'per_page'    => 50,
+            'total_pages' => 1,
+        ]);
+    }
+
+    public function get_columns() {
+        return [
+            'user'       => __( 'User', 'wpam' ),
+            'reason'     => __( 'Reason', 'wpam' ),
+            'flagged_at' => __( 'Date', 'wpam' ),
+        ];
+    }
+
+    protected function column_user( $item ) {
+        $user = get_user_by( 'id', $item['user_id'] );
+        return $user ? esc_html( $user->display_name ) : sprintf( '#%d', $item['user_id'] );
+    }
+
+    protected function column_default( $item, $column_name ) {
+        return isset( $item[ $column_name ] ) ? esc_html( $item[ $column_name ] ) : '';
+    }
+
+    public function no_items() {
+        _e( 'No flagged users.', 'wpam' );
+    }
+}

--- a/includes/class-wpam-bid.php
+++ b/includes/class-wpam-bid.php
@@ -45,6 +45,10 @@ class WPAM_Bid {
             ],
             [ '%d', '%d', '%s', '%s', '%s' ]
         );
+
+        if ( class_exists( '\\WPAM\\Includes\\WPAM_Fraud_Detector' ) ) {
+            \WPAM\Includes\WPAM_Fraud_Detector::analyze_bid( $bid_id, $user_id );
+        }
     }
 
     public function place_bid() {

--- a/includes/class-wpam-fraud-detector.php
+++ b/includes/class-wpam-fraud-detector.php
@@ -1,0 +1,57 @@
+<?php
+namespace WPAM\Includes;
+
+class WPAM_Fraud_Detector {
+    /**
+     * Analyze a newly logged bid for suspicious patterns.
+     *
+     * @param int $bid_id  Bid ID just logged.
+     * @param int $user_id User ID who placed the bid.
+     */
+    public static function analyze_bid( $bid_id, $user_id ) {
+        global $wpdb;
+        $audit = $wpdb->prefix . 'wc_auction_audit';
+        $row   = $wpdb->get_row( $wpdb->prepare( "SELECT ip, logged_at FROM $audit WHERE bid_id = %d", $bid_id ), ARRAY_A );
+        if ( ! $row ) {
+            return;
+        }
+        $ip        = $row['ip'];
+        $logged_at = $row['logged_at'];
+
+        // Pattern 1: Same IP used by multiple users within last day.
+        $count = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(DISTINCT user_id) FROM $audit WHERE ip = %s AND logged_at >= DATE_SUB(%s, INTERVAL 1 DAY)", $ip, $logged_at ) );
+        if ( intval( $count ) > 1 ) {
+            self::flag_user( $user_id, sprintf( /* translators: %s: IP address */ __( 'Shared IP detected: %s', 'wpam' ), $ip ) );
+        }
+
+        // Pattern 2: Rapid bid frequency from same user within 10 seconds.
+        $freq = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $audit WHERE user_id = %d AND logged_at >= DATE_SUB(%s, INTERVAL 10 SECOND)", $user_id, $logged_at ) );
+        if ( intval( $freq ) >= 3 ) {
+            self::flag_user( $user_id, __( 'High bid frequency', 'wpam' ) );
+        }
+    }
+
+    /**
+     * Record a flagged user event.
+     *
+     * @param int    $user_id User ID being flagged.
+     * @param string $reason  Reason for flagging.
+     */
+    private static function flag_user( $user_id, $reason ) {
+        global $wpdb;
+        $table = $wpdb->prefix . 'wpam_flagged_users';
+        $exists = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM $table WHERE user_id = %d AND reason = %s", $user_id, $reason ) );
+        if ( $exists ) {
+            return;
+        }
+        $wpdb->insert(
+            $table,
+            [
+                'user_id'    => $user_id,
+                'reason'     => $reason,
+                'flagged_at' => current_time( 'mysql' ),
+            ],
+            [ '%d', '%s', '%s' ]
+        );
+    }
+}

--- a/includes/class-wpam-install.php
+++ b/includes/class-wpam-install.php
@@ -60,7 +60,19 @@ class WPAM_Install {
             KEY bid_id (bid_id),
             KEY user_id (user_id)
         ) $charset_collate;";
-		dbDelta( $audit_sql );
+        dbDelta( $audit_sql );
+
+                // Flagged users table
+                $flag_table = $wpdb->prefix . 'wpam_flagged_users';
+                $flag_sql   = "CREATE TABLE IF NOT EXISTS $flag_table (
+            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+            user_id bigint(20) unsigned NOT NULL,
+            reason varchar(255) NOT NULL,
+            flagged_at datetime NOT NULL,
+            PRIMARY KEY  (id),
+            KEY user_id (user_id)
+        ) $charset_collate;";
+                dbDelta( $flag_sql );
 
 		// Admin logs table
 		$logs_table = $wpdb->prefix . 'wc_auction_logs';


### PR DESCRIPTION
## Summary
- add `WPAM_Fraud_Detector` to analyze the audit log
- store flagged user events in new DB table
- call the detector on every bid
- expose a list of flagged users in admin

## Testing
- `WP_TESTS_DIR=vendor/wp-phpunit/wp-phpunit vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/test-audit-log.php` *(fails: Class "PHPUnit\TextUI\Command" not found)*
- `vendor/bin/phpcs includes/class-wpam-fraud-detector.php admin/class-wpam-flagged-table.php --standard=phpcs.xml` *(fails: numerous coding standard errors)*

------
https://chatgpt.com/codex/tasks/task_e_688a1ae9f54c8333b87e12eb843296db