### PR TITLE
Limit auction extensions

### DIFF
--- a/admin/class-wpam-admin.php
+++ b/admin/class-wpam-admin.php
@@ -92,8 +92,9 @@ class WPAM_Admin {
 		register_setting( 'wpam_settings', 'wpam_pusher_secret' );
 		register_setting( 'wpam_settings', 'wpam_pusher_cluster' );
 		register_setting( 'wpam_settings', 'wpam_soft_close_threshold' );
-		register_setting( 'wpam_settings', 'wpam_soft_close_extend' );
-		register_setting( 'wpam_settings', 'wpam_realtime_provider' );
+                register_setting( 'wpam_settings', 'wpam_soft_close_extend' );
+                register_setting( 'wpam_settings', 'wpam_max_extensions' );
+                register_setting( 'wpam_settings', 'wpam_realtime_provider' );
 
 		register_setting( 'wpam_settings', 'wpam_default_auction_type' );
 		register_setting( 'wpam_settings', 'wpam_enable_proxy_bidding' );
@@ -119,13 +120,21 @@ class WPAM_Admin {
 			'wpam_general'
 		);
 
-		add_settings_field(
-			'wpam_soft_close_extend',
-			__( 'Extension Duration (seconds)', 'wpam' ),
-			array( $this, 'field_soft_close_extend' ),
-			'wpam_settings',
-			'wpam_general'
-		);
+                add_settings_field(
+                        'wpam_soft_close_extend',
+                        __( 'Extension Duration (seconds)', 'wpam' ),
+                        array( $this, 'field_soft_close_extend' ),
+                        'wpam_settings',
+                        'wpam_general'
+                );
+
+                add_settings_field(
+                        'wpam_max_extensions',
+                        __( 'Maximum Extensions', 'wpam' ),
+                        array( $this, 'field_max_extensions' ),
+                        'wpam_settings',
+                        'wpam_general'
+                );
 
 		add_settings_field(
 			'wpam_default_increment',
@@ -301,10 +310,15 @@ class WPAM_Admin {
 		echo '<input type="number" class="small-text" name="wpam_soft_close_threshold" value="' . $value . '" />';
 	}
 
-	public function field_soft_close_extend() {
-		$value = esc_attr( get_option( 'wpam_soft_close_extend', 30 ) );
-		echo '<input type="number" class="small-text" name="wpam_soft_close_extend" value="' . $value . '" />';
-	}
+        public function field_soft_close_extend() {
+                $value = esc_attr( get_option( 'wpam_soft_close_extend', 30 ) );
+                echo '<input type="number" class="small-text" name="wpam_soft_close_extend" value="' . $value . '" />';
+        }
+
+        public function field_max_extensions() {
+                $value = esc_attr( get_option( 'wpam_max_extensions', 0 ) );
+                echo '<input type="number" class="small-text" name="wpam_max_extensions" value="' . $value . '" />';
+        }
 
 	public function field_default_increment() {
 		$value = esc_attr( get_option( 'wpam_default_increment', 1 ) );
@@ -564,9 +578,10 @@ class WPAM_Admin {
 			'wpam_pusher_key',
 			'wpam_pusher_secret',
 			'wpam_pusher_cluster',
-			'wpam_soft_close_threshold',
-			'wpam_soft_close_extend',
-			'wpam_realtime_provider',
+                        'wpam_soft_close_threshold',
+                        'wpam_soft_close_extend',
+                        'wpam_max_extensions',
+                        'wpam_realtime_provider',
 			'wpam_require_kyc',
 			'wpam_default_auction_type',
 			'wpam_enable_proxy_bidding',

--- a/admin/js/settings-app.js
+++ b/admin/js/settings-app.js
@@ -159,6 +159,12 @@
         hasError = true;
       }
 
+      const maxExt = parseInt(settings.wpam_max_extensions, 10);
+      if (isNaN(maxExt) || maxExt < 0) {
+        newErrors.wpam_max_extensions = 'Must be zero or more.';
+        hasError = true;
+      }
+
       if (settings.wpam_enable_twilio) {
         if (!settings.wpam_twilio_sid) {
           newErrors.wpam_twilio_sid = 'Required when Twilio is enabled.';
@@ -227,6 +233,13 @@
           value: settings.wpam_soft_close_extend || '',
           onChange: (v) => updateField('wpam_soft_close_extend', v),
           error: errors.wpam_soft_close_extend,
+        }),
+        createElement(TextControl, {
+          label: 'Maximum Extensions',
+          help: 'Limit how many times an auction can be extended. 0 = unlimited.',
+          value: settings.wpam_max_extensions || '',
+          onChange: (v) => updateField('wpam_max_extensions', v),
+          error: errors.wpam_max_extensions,
         }),
         createElement(ToggleControl, {
           label: labelWithTip(

--- a/includes/class-wpam-bid.php
+++ b/includes/class-wpam-bid.php
@@ -192,13 +192,19 @@ class WPAM_Bid {
             $extension = $legacy;
         }
 
+        $extension_count = (int) get_post_meta( $auction_id, '_auction_extension_count', true );
+        $max_extensions  = absint( get_option( 'wpam_max_extensions', 0 ) );
+
         if ( $threshold > 0 && $end_ts - $now <= $threshold ) {
-            $new_end_ts = $end_ts + $extension;
-            $new_end    = wp_date( 'Y-m-d H:i:s', $new_end_ts, wp_timezone() );
-            update_post_meta( $auction_id, '_auction_end', $new_end );
-            wp_clear_scheduled_hook( 'wpam_auction_end', [ $auction_id ] );
-            wp_schedule_single_event( (int) get_gmt_from_date( $new_end, 'U' ), 'wpam_auction_end', [ $auction_id ] );
-            $extended = true;
+            if ( 0 === $max_extensions || $extension_count < $max_extensions ) {
+                $new_end_ts = $end_ts + $extension;
+                $new_end    = wp_date( 'Y-m-d H:i:s', $new_end_ts, wp_timezone() );
+                update_post_meta( $auction_id, '_auction_end', $new_end );
+                update_post_meta( $auction_id, '_auction_extension_count', $extension_count + 1 );
+                wp_clear_scheduled_hook( 'wpam_auction_end', [ $auction_id ] );
+                wp_schedule_single_event( (int) get_gmt_from_date( $new_end, 'U' ), 'wpam_auction_end', [ $auction_id ] );
+                $extended = true;
+            }
         }
 
         // SMS notification via Twilio if enabled
@@ -392,13 +398,19 @@ class WPAM_Bid {
             $extension = $legacy;
         }
 
+        $extension_count = (int) get_post_meta( $auction_id, '_auction_extension_count', true );
+        $max_extensions  = absint( get_option( 'wpam_max_extensions', 0 ) );
+
         if ( $threshold > 0 && $end_ts - $now <= $threshold ) {
-            $new_end_ts = $end_ts + $extension;
-            $new_end    = wp_date( 'Y-m-d H:i:s', $new_end_ts, wp_timezone() );
-            update_post_meta( $auction_id, '_auction_end', $new_end );
-            wp_clear_scheduled_hook( 'wpam_auction_end', [ $auction_id ] );
-            wp_schedule_single_event( (int) get_gmt_from_date( $new_end, 'U' ), 'wpam_auction_end', [ $auction_id ] );
-            $extended = true;
+            if ( 0 === $max_extensions || $extension_count < $max_extensions ) {
+                $new_end_ts = $end_ts + $extension;
+                $new_end    = wp_date( 'Y-m-d H:i:s', $new_end_ts, wp_timezone() );
+                update_post_meta( $auction_id, '_auction_end', $new_end );
+                update_post_meta( $auction_id, '_auction_extension_count', $extension_count + 1 );
+                wp_clear_scheduled_hook( 'wpam_auction_end', [ $auction_id ] );
+                wp_schedule_single_event( (int) get_gmt_from_date( $new_end, 'U' ), 'wpam_auction_end', [ $auction_id ] );
+                $extended = true;
+            }
         }
 
         if ( ! $silent_enabled && get_option( 'wpam_enable_twilio' ) ) {


### PR DESCRIPTION
## Summary
- track soft-close extensions with `_auction_extension_count`
- limit extensions based on new `wpam_max_extensions` setting
- expose max extension setting in admin UI

## Testing
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/test-bid.php` *(fails: Error establishing a database connection)*
- `vendor/bin/phpcs includes/class-wpam-bid.php` *(fails: various coding standard errors)*

------
https://chatgpt.com/codex/tasks/task_e_688a2ae350448333922b89e9c707aae7