### PR TITLE
Add toggle for email notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Future versions may swap to WebSocket providers found under `includes/api-integr
 Under **Auctions → Settings → Realtime Integration** you can select `None` or `Pusher` as the provider. Enter your Pusher app credentials to enable realtime WebSocket updates.
 Twilio SMS notifications can be toggled via the `Enable Twilio Notifications` option (`wpam_enable_twilio`).
 Firebase push notifications are available through the `Enable Firebase` option (`wpam_enable_firebase`) once you provide a valid server key.
+Email alerts are on by default. They can be disabled via the `Enable Email Notifications` option (`wpam_enable_email`). If a SendGrid API key is provided emails will be sent through SendGrid.
 
 ### React frontend
 

--- a/admin/class-wpam-admin.php
+++ b/admin/class-wpam-admin.php
@@ -78,8 +78,9 @@ class WPAM_Admin {
 	public function register_settings() {
 		register_setting( 'wpam_settings', 'wpam_default_increment' );
 		register_setting( 'wpam_settings', 'wpam_soft_close' );
-		register_setting( 'wpam_settings', 'wpam_enable_twilio' );
-		register_setting( 'wpam_settings', 'wpam_enable_firebase' );
+                register_setting( 'wpam_settings', 'wpam_enable_twilio' );
+                register_setting( 'wpam_settings', 'wpam_enable_firebase' );
+                register_setting( 'wpam_settings', 'wpam_enable_email' );
 		register_setting( 'wpam_settings', 'wpam_firebase_server_key' );
 		register_setting( 'wpam_settings', 'wpam_sendgrid_key' );
 		register_setting( 'wpam_settings', 'wpam_require_kyc' );
@@ -152,13 +153,21 @@ class WPAM_Admin {
 			'wpam_general'
 		);
 
-		add_settings_field(
-			'wpam_enable_twilio',
-			__( 'Enable Twilio Notifications', 'wpam' ),
-			array( $this, 'field_enable_twilio' ),
-			'wpam_settings',
-			'wpam_providers'
-		);
+                add_settings_field(
+                        'wpam_enable_twilio',
+                        __( 'Enable Twilio Notifications', 'wpam' ),
+                        array( $this, 'field_enable_twilio' ),
+                        'wpam_settings',
+                        'wpam_providers'
+                );
+
+                add_settings_field(
+                        'wpam_enable_email',
+                        __( 'Enable Email Notifications', 'wpam' ),
+                        array( $this, 'field_enable_email' ),
+                        'wpam_settings',
+                        'wpam_providers'
+                );
 
 		add_settings_field(
 			'wpam_enable_firebase',
@@ -330,10 +339,15 @@ class WPAM_Admin {
 		echo '<input type="number" class="small-text" name="wpam_soft_close" value="' . $value . '" />';
 	}
 
-	public function field_enable_twilio() {
-		$value = get_option( 'wpam_enable_twilio', false );
-		echo '<input type="checkbox" name="wpam_enable_twilio" value="1"' . checked( 1, $value, false ) . ' />';
-	}
+        public function field_enable_twilio() {
+                $value = get_option( 'wpam_enable_twilio', false );
+                echo '<input type="checkbox" name="wpam_enable_twilio" value="1"' . checked( 1, $value, false ) . ' />';
+        }
+
+        public function field_enable_email() {
+                $value = get_option( 'wpam_enable_email', true );
+                echo '<input type="checkbox" name="wpam_enable_email" value="1"' . checked( 1, $value, false ) . ' />';
+        }
 
 	public function field_enable_firebase() {
 		$value = get_option( 'wpam_enable_firebase', false );
@@ -567,9 +581,10 @@ class WPAM_Admin {
 		return array(
 			'wpam_default_increment',
 			'wpam_soft_close',
-			'wpam_enable_twilio',
-			'wpam_enable_firebase',
-			'wpam_firebase_server_key',
+                        'wpam_enable_twilio',
+                        'wpam_enable_firebase',
+                        'wpam_enable_email',
+                        'wpam_firebase_server_key',
 			'wpam_sendgrid_key',
 			'wpam_twilio_sid',
 			'wpam_twilio_token',

--- a/admin/js/settings-app.js
+++ b/admin/js/settings-app.js
@@ -301,6 +301,12 @@
         'div',
         null,
         createElement(ToggleControl, {
+          label: labelWithTip('Enable Email Notifications', 'Send emails via WordPress or SendGrid.'),
+          help: 'Send emails via WordPress or SendGrid.',
+          checked: !!settings.wpam_enable_email,
+          onChange: (v) => updateField('wpam_enable_email', v ? 1 : 0),
+        }),
+        createElement(ToggleControl, {
           label: labelWithTip('Enable Twilio Notifications', 'Send SMS messages using Twilio.'),
           help: 'Send SMS messages using Twilio.',
           checked: !!settings.wpam_enable_twilio,

--- a/includes/class-wpam-notifications.php
+++ b/includes/class-wpam-notifications.php
@@ -5,6 +5,7 @@ class WPAM_Notifications {
     public static function send_to_user( $user_id, $subject, $message ) {
         $sms_enabled   = get_option( 'wpam_enable_twilio', '0' );
         $push_enabled  = get_option( 'wpam_enable_firebase', '0' );
+        $email_enabled = get_option( 'wpam_enable_email', '1' );
         $sendgrid_key  = get_option( 'wpam_sendgrid_key', '' );
 
         $user  = get_user_by( 'id', $user_id );
@@ -30,13 +31,16 @@ class WPAM_Notifications {
             $sent   = ! is_wp_error( $result );
         }
 
-        if ( ! $sent && $sendgrid_key ) {
-            $result = $sendgrid_provider->send( $user->user_email, $message );
-            $sent   = ! is_wp_error( $result );
-        }
+        if ( ! $sent && $email_enabled ) {
+            if ( $sendgrid_key ) {
+                $result = $sendgrid_provider->send( $user->user_email, $message );
+                $sent   = ! is_wp_error( $result );
+            }
 
-        if ( ! $sent ) {
-            wp_mail( $user->user_email, $subject, $message );
+            if ( ! $sent ) {
+                wp_mail( $user->user_email, $subject, $message );
+                $sent = true;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- introduce `Enable Email Notifications` setting
- support toggling email notifications in admin UI
- default to WordPress email with optional SendGrid
- document new setting

## Testing
- `composer install`
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Class "PHPUnit\TextUI\Command" not found)*
- `vendor/bin/phpcs -d memory_limit=512M --standard=phpcs.xml admin includes public`

------
https://chatgpt.com/codex/tasks/task_e_688a30dbda4c83339cd27101272d5ff1