### PR TITLE
Implement variable bid increments

### DIFF
--- a/includes/class-wpam-bid.php
+++ b/includes/class-wpam-bid.php
@@ -104,11 +104,7 @@ class WPAM_Bid {
             }
         }
 
-        $increment = get_post_meta( $auction_id, '_auction_increment', true );
-        if ( '' === $increment ) {
-            $increment = get_option( 'wpam_default_increment', 1 );
-        }
-        $increment = floatval( $increment );
+        $increment = WPAM_Auction::get_bid_increment( $auction_id, $highest );
 
         if ( ! $proxy_enabled ) {
             if ( $bid < $highest + $increment ) {
@@ -312,11 +308,7 @@ class WPAM_Bid {
             }
         }
 
-        $increment = get_post_meta( $auction_id, '_auction_increment', true );
-        if ( '' === $increment ) {
-            $increment = get_option( 'wpam_default_increment', 1 );
-        }
-        $increment = floatval( $increment );
+        $increment = WPAM_Auction::get_bid_increment( $auction_id, $highest );
 
         if ( ! $proxy_enabled ) {
             if ( $bid < $highest + $increment ) {

--- a/tests/test-variable-increment.php
+++ b/tests/test-variable-increment.php
@@ -1,0 +1,69 @@
+<?php
+use WPAM\Includes\WPAM_Bid;
+use WPAM\Includes\WPAM_Install;
+
+class Test_WPAM_Variable_Increment extends WP_Ajax_UnitTestCase {
+    protected $auction_id;
+    protected $user_id;
+
+    public function set_up() : void {
+        parent::set_up();
+        new WPAM_Bid();
+        WPAM_Install::activate();
+        $this->auction_id = $this->factory->post->create([ 'post_type' => 'product' ]);
+        update_post_meta( $this->auction_id, '_auction_start', date( 'Y-m-d H:i:s', time() - 3600 ) );
+        update_post_meta( $this->auction_id, '_auction_end', date( 'Y-m-d H:i:s', time() + 3600 ) );
+        update_post_meta( $this->auction_id, '_auction_variable_increment', 1 );
+        update_post_meta( $this->auction_id, '_auction_variable_increment_rules', "50|2\n100|5" );
+        $this->user_id = $this->factory->user->create();
+        wp_set_current_user( $this->user_id );
+    }
+
+    public function test_initial_increment_enforced() {
+        $_POST = [
+            'nonce'      => wp_create_nonce( 'wpam_place_bid' ),
+            'auction_id' => $this->auction_id,
+            'bid'        => 1,
+        ];
+        try {
+            $this->_handleAjax( 'wpam_place_bid' );
+        } catch ( WPAjaxDieContinueException $e ) {
+            $response = json_decode( $this->_last_response, true );
+            $this->assertFalse( $response['success'] );
+            $this->assertSame( 'Bid too low', $response['data']['message'] );
+            return;
+        }
+        $this->fail( 'Expected low bid rejection' );
+    }
+
+    public function test_increment_changes_with_rules() {
+        $_POST = [
+            'nonce'      => wp_create_nonce( 'wpam_place_bid' ),
+            'auction_id' => $this->auction_id,
+            'bid'        => 2,
+        ];
+        try { $this->_handleAjax( 'wpam_place_bid' ); } catch ( WPAjaxDieContinueException $e ) {}
+
+        $_POST = [
+            'nonce'      => wp_create_nonce( 'wpam_place_bid' ),
+            'auction_id' => $this->auction_id,
+            'bid'        => 60,
+        ];
+        try { $this->_handleAjax( 'wpam_place_bid' ); } catch ( WPAjaxDieContinueException $e ) {}
+
+        $_POST = [
+            'nonce'      => wp_create_nonce( 'wpam_place_bid' ),
+            'auction_id' => $this->auction_id,
+            'bid'        => 62,
+        ];
+        try {
+            $this->_handleAjax( 'wpam_place_bid' );
+        } catch ( WPAjaxDieContinueException $e ) {
+            $response = json_decode( $this->_last_response, true );
+            $this->assertFalse( $response['success'] );
+            $this->assertSame( 'Bid too low', $response['data']['message'] );
+            return;
+        }
+        $this->fail( 'Expected low bid rejection after threshold' );
+    }
+}


### PR DESCRIPTION
## Summary
- support variable bid increments via `_auction_variable_increment_rules`
- parse increment rules and calculate increment dynamically
- apply dynamic increment in `place_bid` and REST handler
- add tests for variable increment logic

## Testing
- `composer install`
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/test-variable-increment.php` *(fails: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_688a7f6454f0833391ed2667140f8c75