### PR TITLE
Add reverse and sealed auction logic

### DIFF
--- a/includes/class-wpam-auction.php
+++ b/includes/class-wpam-auction.php
@@ -434,8 +434,10 @@ class WPAM_Auction {
 	public function handle_auction_end( $auction_id ) {
 		global $wpdb;
 
-		$table   = $wpdb->prefix . 'wc_auction_bids';
-		$highest = $wpdb->get_row( $wpdb->prepare( "SELECT user_id, bid_amount FROM $table WHERE auction_id = %d ORDER BY bid_amount DESC LIMIT 1", $auction_id ), ARRAY_A );
+                $table   = $wpdb->prefix . 'wc_auction_bids';
+                $reverse = get_post_meta( $auction_id, '_auction_type', true ) === 'reverse';
+                $order   = $reverse ? 'ASC' : 'DESC';
+                $highest = $wpdb->get_row( $wpdb->prepare( "SELECT user_id, bid_amount FROM $table WHERE auction_id = %d ORDER BY bid_amount {$order} LIMIT 1", $auction_id ), ARRAY_A );
 
 		$ending_reason = '';
 

--- a/tests/test-auction-types.php
+++ b/tests/test-auction-types.php
@@ -1,0 +1,94 @@
+<?php
+use WPAM\Includes\WPAM_Bid;
+use WPAM\Includes\WPAM_Install;
+
+class Test_WPAM_Auction_Types extends WP_Ajax_UnitTestCase {
+    protected $bid;
+    public function set_up() : void {
+        parent::set_up();
+        $this->bid = new WPAM_Bid();
+        WPAM_Install::activate();
+    }
+
+    public function test_reverse_lowest_bid_wins() {
+        $auction_id = $this->factory->post->create([ 'post_type' => 'product' ]);
+        update_post_meta( $auction_id, '_auction_type', 'reverse' );
+        update_post_meta( $auction_id, '_auction_start', date( 'Y-m-d H:i:s', time() - 3600 ) );
+        update_post_meta( $auction_id, '_auction_end', date( 'Y-m-d H:i:s', time() + 3600 ) );
+        $user_id = $this->factory->user->create();
+        wp_set_current_user( $user_id );
+
+        $_POST = [
+            'nonce'      => wp_create_nonce( 'wpam_place_bid' ),
+            'auction_id' => $auction_id,
+            'bid'        => 100,
+        ];
+        try { $this->_handleAjax( 'wpam_place_bid' ); } catch ( WPAjaxDieContinueException $e ) {}
+
+        $_POST = [
+            'nonce'      => wp_create_nonce( 'wpam_place_bid' ),
+            'auction_id' => $auction_id,
+            'bid'        => 120,
+        ];
+        try { $this->_handleAjax( 'wpam_place_bid' ); } catch ( WPAjaxDieContinueException $e ) {
+            $resp = json_decode( $this->_last_response, true );
+            $this->assertFalse( $resp['success'] );
+            $this->assertSame( 'Bid too high', $resp['data']['message'] );
+        }
+
+        $_POST = [
+            'nonce'      => wp_create_nonce( 'wpam_place_bid' ),
+            'auction_id' => $auction_id,
+            'bid'        => 90,
+        ];
+        try { $this->_handleAjax( 'wpam_place_bid' ); } catch ( WPAjaxDieContinueException $e ) {
+            $resp = json_decode( $this->_last_response, true );
+            $this->assertTrue( $resp['success'] );
+        }
+
+        $_POST = [
+            'nonce'      => wp_create_nonce( 'wpam_get_highest_bid' ),
+            'auction_id' => $auction_id,
+        ];
+        try { $this->_handleAjax( 'wpam_get_highest_bid' ); } catch ( WPAjaxDieContinueException $e ) {
+            $resp = json_decode( $this->_last_response, true );
+        }
+        $this->assertSame( 90.0, floatval( $resp['data']['highest_bid'] ) );
+    }
+
+    public function test_sealed_bid_hidden_until_end() {
+        $auction_id = $this->factory->post->create([ 'post_type' => 'product' ]);
+        update_post_meta( $auction_id, '_auction_type', 'sealed' );
+        update_post_meta( $auction_id, '_auction_start', date( 'Y-m-d H:i:s', time() - 3600 ) );
+        update_post_meta( $auction_id, '_auction_end', date( 'Y-m-d H:i:s', time() + 3600 ) );
+        $user_id = $this->factory->user->create();
+        wp_set_current_user( $user_id );
+
+        $_POST = [
+            'nonce'      => wp_create_nonce( 'wpam_place_bid' ),
+            'auction_id' => $auction_id,
+            'bid'        => 50,
+        ];
+        try { $this->_handleAjax( 'wpam_place_bid' ); } catch ( WPAjaxDieContinueException $e ) {}
+
+        $_POST = [
+            'nonce'      => wp_create_nonce( 'wpam_get_highest_bid' ),
+            'auction_id' => $auction_id,
+        ];
+        try { $this->_handleAjax( 'wpam_get_highest_bid' ); } catch ( WPAjaxDieContinueException $e ) {
+            $resp = json_decode( $this->_last_response, true );
+        }
+        $this->assertSame( 0.0, floatval( $resp['data']['highest_bid'] ) );
+
+        update_post_meta( $auction_id, '_auction_end', date( 'Y-m-d H:i:s', time() - 10 ) );
+
+        $_POST = [
+            'nonce'      => wp_create_nonce( 'wpam_get_highest_bid' ),
+            'auction_id' => $auction_id,
+        ];
+        try { $this->_handleAjax( 'wpam_get_highest_bid' ); } catch ( WPAjaxDieContinueException $e ) {
+            $resp = json_decode( $this->_last_response, true );
+        }
+        $this->assertSame( 50.0, floatval( $resp['data']['highest_bid'] ) );
+    }
+}


### PR DESCRIPTION
## Summary
- support reverse lowest-bid and sealed auction types
- adjust public HTML display for reverse and sealed auctions
- update Ajax and REST bid handlers
- include tests for new auction type settings

## Testing
- `php -l includes/class-wpam-bid.php`
- `php -l includes/class-wpam-auction.php`
- `php -l includes/class-wpam-html.php`
- `php -l tests/test-auction-types.php`
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/test-auction-types.php` *(fails: Class `PHPUnit\TextUI\Command` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a881c07e08333807aaf214487fa1f