### PR TITLE
Fix uninstall cleanup

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -1,22 +1,34 @@
 <?php
+/**
+ * Uninstall routine for WP Auction Manager.
+ *
+ * Drops custom database tables when the plugin is deleted.
+ *
+ * @package WP_Auction_Manager
+ */
+
 if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
-    exit();
+	exit();
 }
 
 // Verify the current user has permission to uninstall plugins.
 if ( ! current_user_can( 'activate_plugins' ) ) {
-    return;
+	return;
 }
 
 global $wpdb;
 
 // Drop custom tables created by the plugin.
-$tables = [
-    $wpdb->prefix . 'wc_auction_bids',
-    $wpdb->prefix . 'wc_auction_watchlists',
-    $wpdb->prefix . 'wc_auction_messages',
-];
+$tables = array(
+	$wpdb->prefix . 'wc_auction_bids',
+	$wpdb->prefix . 'wc_auction_watchlists',
+	$wpdb->prefix . 'wc_auction_messages',
+	$wpdb->prefix . 'wc_auction_audit',
+	$wpdb->prefix . 'wpam_flagged_users',
+	$wpdb->prefix . 'wc_auction_logs',
+);
 
 foreach ( $tables as $table ) {
-    $wpdb->query( "DROP TABLE IF EXISTS $table" );
+// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange
+	$wpdb->query( "DROP TABLE IF EXISTS {$table}" );
 }


### PR DESCRIPTION
## Summary
- drop more plugin tables on uninstall
- document uninstall file and keep capability checks

## Testing
- `vendor/bin/phpunit` *(fails: shows usage)*
- `vendor/bin/phpcs uninstall.php`

------
https://chatgpt.com/codex/tasks/task_e_688a8f5fb3308333aeaad9800154e764