### PR TITLE
Add toast notifications for bidding

### DIFF
--- a/admin/class-wpam-admin.php
+++ b/admin/class-wpam-admin.php
@@ -605,9 +605,10 @@ class WPAM_Admin {
 			'wpam_enable_proxy_bidding',
 			'wpam_enable_silent_bidding',
 			'wpam_buyer_premium',
-			'wpam_seller_fee',
-			'wpam_webhook_url',
-		);
+                        'wpam_seller_fee',
+                        'wpam_webhook_url',
+                        'wpam_enable_toasts',
+                );
 
 		register_rest_route(
 			'wpam/v1',

--- a/admin/js/settings-app.js
+++ b/admin/js/settings-app.js
@@ -423,6 +423,12 @@
           error: errors.wpam_sendgrid_key,
         }),
         createElement(ToggleControl, {
+          label: 'Enable Toast Notices',
+          help: 'Show on-screen bid status messages.',
+          checked: !!settings.wpam_enable_toasts,
+          onChange: (v) => updateField('wpam_enable_toasts', v ? 1 : 0),
+        }),
+        createElement(ToggleControl, {
           label: labelWithTip(
             'Enable Firebase',
             'Push notifications via Firebase Cloud Messaging.'

--- a/public/class-wpam-public.php
+++ b/public/class-wpam-public.php
@@ -59,21 +59,23 @@ class WPAM_Public {
 		wp_enqueue_style( 'wpam-frontend', WPAM_PLUGIN_URL . 'public/css/wpam-frontend.css', array( 'woocommerce-general' ), WPAM_PLUGIN_VERSION );
 
                 wp_enqueue_script( 'wpam-ajax-bid', WPAM_PLUGIN_URL . 'public/js/ajax-bid.js', array( 'jquery', 'countdown' ), WPAM_PLUGIN_VERSION, true );
-		wp_localize_script(
-			'wpam-ajax-bid',
-			'wpam_ajax',
-			array(
-				'ajax_url'            => admin_url( 'admin-ajax.php' ),
-				'bid_nonce'           => wp_create_nonce( 'wpam_place_bid' ),
-				'watchlist_nonce'     => wp_create_nonce( 'wpam_toggle_watchlist' ),
-				'watchlist_get_nonce' => wp_create_nonce( 'wpam_get_watchlist' ),
-				'highest_nonce'       => wp_create_nonce( 'wpam_get_highest_bid' ),
-				'pusher_enabled'      => $pusher_enabled,
-				'pusher_key'          => get_option( 'wpam_pusher_key' ),
-				'pusher_cluster'      => get_option( 'wpam_pusher_cluster' ),
-				'pusher_channel'      => 'wpam-auctions',
-			)
-		);
+                wp_localize_script(
+                        'wpam-ajax-bid',
+                        'wpam_ajax',
+                        array(
+                                'ajax_url'            => admin_url( 'admin-ajax.php' ),
+                                'bid_nonce'           => wp_create_nonce( 'wpam_place_bid' ),
+                                'watchlist_nonce'     => wp_create_nonce( 'wpam_toggle_watchlist' ),
+                                'watchlist_get_nonce' => wp_create_nonce( 'wpam_get_watchlist' ),
+                                'highest_nonce'       => wp_create_nonce( 'wpam_get_highest_bid' ),
+                                'pusher_enabled'      => $pusher_enabled,
+                                'pusher_key'          => get_option( 'wpam_pusher_key' ),
+                                'pusher_cluster'      => get_option( 'wpam_pusher_cluster' ),
+                                'pusher_channel'      => 'wpam-auctions',
+                                'current_user_id'     => get_current_user_id(),
+                                'show_notices'        => (bool) get_option( 'wpam_enable_toasts', 1 ),
+                        )
+                );
 
 		wp_enqueue_script( 'wpam-ajax-messages', WPAM_PLUGIN_URL . 'public/js/ajax-messages.js', array( 'jquery' ), WPAM_PLUGIN_VERSION, true );
 		wp_localize_script(

--- a/public/css/wpam-frontend.css
+++ b/public/css/wpam-frontend.css
@@ -36,3 +36,15 @@
 .wpam-watchlist-button {
     margin-top: 5px;
 }
+
+.wpam-toast {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    background: #333;
+    color: #fff;
+    padding: 10px 15px;
+    border-radius: 3px;
+    z-index: 9999;
+    display: none;
+}


### PR DESCRIPTION
## Summary
- expose the current user ID and a toast toggle to frontend scripts
- allow enabling toast notifications in settings
- style `.wpam-toast` element
- track personal bid status in `ajax-bid.js`
- show toast messages on bid updates from Pusher or polling

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: Class "PHPUnit\TextUI\Command" not found)*
- `vendor/bin/phpcs -d memory_limit=256M admin/class-wpam-admin.php admin/js/settings-app.js public/class-wpam-public.php public/css/wpam-frontend.css public/js/ajax-bid.js` *(fails: numerous coding standard errors)*

------
https://chatgpt.com/codex/tasks/task_e_688a999f99e08333801c68f53467c6fe