### PR TITLE
Add SMS alerts for new highest bidder

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ The older `Soft Close Duration` option is still honored when the new values are 
 
 ### Integration settings
 
-The **Integrations** tab lets you connect optional services.
+-The **Integrations** tab lets you connect optional services.
 
-- **Twilio** – enable SMS alerts and fill in your account SID, token and from number.
+- **Twilio** – enable SMS alerts and fill in your account SID, token and from number. Enable "Bid SMS Alerts" to text bidders when they take or lose the lead.
 - **Firebase** – toggle Firebase push notifications and provide the server key.
 - **Pusher** – choose "Pusher" under Realtime Provider and enter your app credentials for WebSocket updates.
 
@@ -142,7 +142,7 @@ The plugin uses AJAX polling by default to refresh the current highest bid every
 Future versions may swap to WebSocket providers found under `includes/api-integrations`.
 
 Under **Auctions → Settings → Realtime Integration** you can select `None` or `Pusher` as the provider. Enter your Pusher app credentials to enable realtime WebSocket updates.
-Twilio SMS notifications can be toggled via the `Enable Twilio Notifications` option (`wpam_enable_twilio`).
+Twilio SMS notifications can be toggled via the `Enable Twilio Notifications` option (`wpam_enable_twilio`). When enabled, bid lead alerts are controlled by the `Enable Bid SMS Alerts` option (`wpam_lead_sms_alerts`).
 Firebase push notifications are available through the `Enable Firebase` option (`wpam_enable_firebase`) once you provide a valid server key.
 Email alerts are on by default. They can be disabled via the `Enable Email Notifications` option (`wpam_enable_email`). If a SendGrid API key is provided emails will be sent through SendGrid.
 

--- a/admin/class-wpam-admin.php
+++ b/admin/class-wpam-admin.php
@@ -82,6 +82,7 @@ class WPAM_Admin {
 		register_setting( 'wpam_settings', 'wpam_default_increment' );
 		register_setting( 'wpam_settings', 'wpam_soft_close' );
                 register_setting( 'wpam_settings', 'wpam_enable_twilio' );
+                register_setting( 'wpam_settings', 'wpam_lead_sms_alerts' );
                 register_setting( 'wpam_settings', 'wpam_enable_firebase' );
                 register_setting( 'wpam_settings', 'wpam_enable_email' );
 		register_setting( 'wpam_settings', 'wpam_firebase_server_key' );
@@ -204,13 +205,21 @@ class WPAM_Admin {
 			'wpam_twilio'
 		);
 
-		add_settings_field(
-			'wpam_twilio_from',
-			__( 'Twilio From Number', 'wpam' ),
-			array( $this, 'field_twilio_from' ),
-			'wpam_settings',
-			'wpam_twilio'
-		);
+                add_settings_field(
+                        'wpam_twilio_from',
+                        __( 'Twilio From Number', 'wpam' ),
+                        array( $this, 'field_twilio_from' ),
+                        'wpam_settings',
+                        'wpam_twilio'
+                );
+
+                add_settings_field(
+                        'wpam_lead_sms_alerts',
+                        __( 'Enable Bid SMS Alerts', 'wpam' ),
+                        array( $this, 'field_lead_sms_alerts' ),
+                        'wpam_settings',
+                        'wpam_twilio'
+                );
 
 		add_settings_field(
 			'wpam_sendgrid_key',
@@ -287,10 +296,15 @@ class WPAM_Admin {
 		echo '<input type="text" class="regular-text" name="wpam_twilio_token" value="' . $value . '" />';
 	}
 
-	public function field_twilio_from() {
-		$value = esc_attr( get_option( 'wpam_twilio_from', '' ) );
-		echo '<input type="text" class="regular-text" name="wpam_twilio_from" value="' . $value . '" />';
-	}
+        public function field_twilio_from() {
+                $value = esc_attr( get_option( 'wpam_twilio_from', '' ) );
+                echo '<input type="text" class="regular-text" name="wpam_twilio_from" value="' . $value . '" />';
+        }
+
+        public function field_lead_sms_alerts() {
+                $value = get_option( 'wpam_lead_sms_alerts', false );
+                echo '<input type="checkbox" name="wpam_lead_sms_alerts" value="1"' . checked( 1, $value, false ) . ' />';
+        }
 
 	public function field_pusher_app_id() {
 		$value = esc_attr( get_option( 'wpam_pusher_app_id', '' ) );
@@ -585,6 +599,7 @@ class WPAM_Admin {
 			'wpam_default_increment',
 			'wpam_soft_close',
                         'wpam_enable_twilio',
+                        'wpam_lead_sms_alerts',
                         'wpam_enable_firebase',
                         'wpam_enable_email',
                         'wpam_firebase_server_key',

--- a/admin/js/settings-app.js
+++ b/admin/js/settings-app.js
@@ -415,6 +415,12 @@
           onChange: (v) => updateField('wpam_twilio_from', v),
           error: errors.wpam_twilio_from,
         }),
+        createElement(ToggleControl, {
+          label: 'Enable Bid SMS Alerts',
+          help: 'Notify bidders via SMS when bids take or lose the lead.',
+          checked: !!settings.wpam_lead_sms_alerts,
+          onChange: (v) => updateField('wpam_lead_sms_alerts', v ? 1 : 0),
+        }),
         createElement(TextControl, {
           label: 'SendGrid API Key',
           help: 'Used for sending email notifications.',


### PR DESCRIPTION
## Summary
- alert new leader and prior leader via Twilio
- toggle these SMS notifications in settings
- document bid SMS alerts

## Testing
- `composer install`
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Error establishing a database connection)*
- `vendor/bin/phpcs -d memory_limit=512M --standard=phpcs.xml admin/class-wpam-admin.php admin/js/settings-app.js includes/class-wpam-bid.php` *(fails: numerous coding standard errors)*

------
https://chatgpt.com/codex/tasks/task_e_688a9e24b89c8333a323a299ba0b18f5