### PR TITLE
Track lead user and expose via API

### DIFF
--- a/public/js/ajax-bid.js
+++ b/public/js/ajax-bid.js
@@ -31,19 +31,26 @@ jQuery(function ($) {
     toastr[type](msg);
   }
 
-  function checkBidStatus(id, highest) {
+  function checkBidStatus(id, highest, leadUser) {
     if (typeof userBids[id] === 'undefined') {
       return;
     }
     let status = '';
-    if (highest > userBids[id]) {
+    const currentUser = parseInt(wpam_ajax.current_user_id, 10);
+    if (leadUser && currentUser && leadUser === currentUser) {
+      status = 'max';
+    } else if (highest > userBids[id]) {
       status = 'outbid';
     } else if (highest === userBids[id]) {
       status = 'winning';
     }
     if (status && bidStatus[id] !== status) {
       bidStatus[id] = status;
-      showToast(status === 'winning' ? "You're winning" : "You've been outbid");
+      if (status === 'max') {
+        showToast("You're the max bidder");
+      } else {
+        showToast(status === 'winning' ? "You're winning" : "You've been outbid");
+      }
     }
   }
 
@@ -112,8 +119,9 @@ jQuery(function ($) {
         function (res) {
           if (res.success) {
             const highest = parseFloat(res.data.highest_bid);
+            const lead = res.data.lead_user ? parseInt(res.data.lead_user, 10) : 0;
             bidEl.text(res.data.highest_bid);
-            checkBidStatus(auctionId, highest);
+            checkBidStatus(auctionId, highest, lead);
           }
         }
       );


### PR DESCRIPTION
## Summary
- save the lead bidder whenever a higher max bid is placed
- return the lead bidder ID via highest bid endpoints
- show "You're the max bidder" in `ajax-bid.js`
- send notifications based on the stored lead user

## Testing
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_688af52a205c8333a5eae2dabfd1375a