### PR TITLE
Add auction type field toggle script

### DIFF
--- a/admin/class-wpam-admin.php
+++ b/admin/class-wpam-admin.php
@@ -498,14 +498,21 @@ class WPAM_Admin {
 				'4.6.13',
 				true
 			);
-			wp_enqueue_script(
-				'wpam-date-picker',
-				WPAM_PLUGIN_URL . 'admin/js/auction-date-picker.js',
-				array( 'jquery', 'flatpickr' ),
-				WPAM_PLUGIN_VERSION,
-				true
-			);
-		}
+                        wp_enqueue_script(
+                                'wpam-date-picker',
+                                WPAM_PLUGIN_URL . 'admin/js/auction-date-picker.js',
+                                array( 'jquery', 'flatpickr' ),
+                                WPAM_PLUGIN_VERSION,
+                                true
+                        );
+                       wp_enqueue_script(
+                               'wpam-auction-type-toggle',
+                               WPAM_PLUGIN_URL . 'admin/js/auction-type-toggle.js',
+                               array( 'jquery' ),
+                               WPAM_PLUGIN_VERSION,
+                               true
+                       );
+                }
 
 		$slug        = 'auctions';
 		$admin_pages = array(

--- a/admin/js/auction-type-toggle.js
+++ b/admin/js/auction-type-toggle.js
@@ -1,0 +1,29 @@
+jQuery(function($){
+    function toggleFields(){
+        var type = $('#_auction_type').val();
+        var reserve = $('._auction_reserve_field');
+        var increment = $('._auction_increment_field');
+        var variableInc = $('._auction_variable_increment_field, .show_if_variable_increment');
+        var sealedOpts = $('._auction_proxy_bidding_field, ._auction_silent_bidding_field');
+
+        if(type === 'sealed'){
+            reserve.hide();
+            increment.hide();
+            variableInc.hide();
+            sealedOpts.show();
+        } else if(type === 'reverse'){
+            reserve.show();
+            increment.show();
+            variableInc.show();
+            sealedOpts.hide();
+        } else { // standard
+            reserve.hide();
+            increment.show();
+            variableInc.show();
+            sealedOpts.hide();
+        }
+    }
+
+    $('#_auction_type').on('change', toggleFields);
+    toggleFields();
+});


### PR DESCRIPTION
## Summary
- add JS to toggle auction fields when selecting auction type
- enqueue the script on product edit screens

## Testing
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/ --testdox` *(fails: Class "PHPUnit\TextUI\Command" not found)*
- `vendor/bin/phpcs admin/class-wpam-admin.php admin/js/auction-type-toggle.js` *(fails with coding standard errors)*

------
https://chatgpt.com/codex/tasks/task_e_688affa9c1fc833396b6c40819a531b2