### PR TITLE
Add Reverse auction setting

### DIFF
--- a/admin/js/settings-app.js
+++ b/admin/js/settings-app.js
@@ -342,6 +342,7 @@
           options: [
             { label: 'Standard', value: 'standard' },
             { label: 'Sealed', value: 'sealed' },
+            { label: 'Reverse', value: 'reverse' },
           ],
           onChange: (v) => updateField('wpam_default_auction_type', v),
         }),


### PR DESCRIPTION
## Summary
- extend admin settings to include Reverse auction type

## Testing
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_688b047c5e1c8333bd75305997dc2479