### PR TITLE
Add client alerts for auction edge cases

### DIFF
--- a/languages/wp-auction-manager.pot
+++ b/languages/wp-auction-manager.pot
@@ -41,3 +41,22 @@ msgstr ""
 #: admin/class-wpam-admin.php
 msgid "Firebase Server Key"
 msgstr ""
+#: includes/class-wpam-bid.php
+msgid "Only one bid allowed for sealed auctions"
+msgstr ""
+
+#: includes/class-wpam-bid.php
+msgid "Sealed bid submitted"
+msgstr ""
+
+#: includes/class-wpam-bid.php
+msgid "Max bid reached"
+msgstr ""
+
+#: includes/class-wpam-bid.php
+msgid "Auction extended due to soft close"
+msgstr ""
+
+#: includes/class-wpam-auction.php
+msgid "Reserve price not met"
+msgstr ""

--- a/public/class-wpam-public.php
+++ b/public/class-wpam-public.php
@@ -77,6 +77,14 @@ class WPAM_Public {
                                 'pusher_channel'      => 'wpam-auctions',
                                 'current_user_id'     => get_current_user_id(),
                                 'show_notices'        => (bool) get_option( 'wpam_enable_toasts', 1 ),
+                                'i18n'                => array(
+                                        'max_bidder'       => __( "You're the max bidder", 'wpam' ),
+                                        'winning'          => __( "You're winning", 'wpam' ),
+                                        'outbid'           => __( "You've been outbid", 'wpam' ),
+                                        'auction_extended' => __( 'Auction extended due to soft close', 'wpam' ),
+                                        'max_reached'      => __( 'Max bid reached', 'wpam' ),
+                                        'reserve_not_met'  => __( 'Reserve price not met', 'wpam' ),
+                                ),
                         )
                 );
 


### PR DESCRIPTION
## Summary
- surface new toast messages via localized JS
- enforce single sealed bid per user
- detect proxy max exhaustion and soft close extensions
- expose reserve price status in responses
- add translation strings

## Testing
- `vendor/bin/phpunit` *(fails: no configuration)*
- `vendor/bin/phpcs includes/class-wpam-bid.php public/js/ajax-bid.js -q` *(reports many sniff violations)*

------
https://chatgpt.com/codex/tasks/task_e_688b0b431a1c8333a6e4ed03df896776