### PR TITLE
Add auction ending reminder cron task

### DIFF
--- a/includes/class-wpam-notifications.php
+++ b/includes/class-wpam-notifications.php
@@ -77,4 +77,18 @@ class WPAM_Notifications {
             self::send_to_user( $user_id, $subject, $message );
         }
     }
+
+    public static function notify_auction_reminder( $auction_id ) {
+        global $wpdb;
+        $watchers = $wpdb->get_col( $wpdb->prepare( "SELECT DISTINCT user_id FROM {$wpdb->prefix}wc_auction_watchlists WHERE auction_id = %d", $auction_id ) );
+        if ( empty( $watchers ) ) {
+            return;
+        }
+        $title   = get_the_title( $auction_id );
+        $subject = sprintf( __( 'Auction ending soon: %s', 'wpam' ), $title );
+        $message = sprintf( __( 'The auction "%s" ends in less than 30 minutes. Place your bid now!', 'wpam' ), $title );
+        foreach ( $watchers as $user_id ) {
+            self::send_to_user( $user_id, $subject, $message );
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- send reminder notifications to watchers before auctions end
- schedule new cron job for the reminders

## Testing
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Class "PHPUnit\TextUI\Command" not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b188fea288333990b08e129000fad