### PR TITLE
Add admin log events for auction lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ The older `Soft Close Duration` option is still honored when the new values are 
 - **Firebase** – toggle Firebase push notifications and provide the server key.
 - **Pusher** – choose "Pusher" under Realtime Provider and enter your app credentials for WebSocket updates.
 
+### Admin logs
+
+View auction events under **Auctions → Logs**. Endings, reserve price failures and relists are recorded per auction.
+
 ## Folder structure
 
 ````

--- a/includes/class-wpam-admin-log.php
+++ b/includes/class-wpam-admin-log.php
@@ -2,9 +2,12 @@
 namespace WPAM\Includes;
 
 class WPAM_Admin_Log {
-	const ACTION_SUSPEND    = 'suspend';
-	const ACTION_CANCEL     = 'cancel';
-	const ACTION_PRICE_EDIT = 'price_edit';
+        const ACTION_SUSPEND    = 'suspend';
+        const ACTION_CANCEL     = 'cancel';
+        const ACTION_PRICE_EDIT = 'price_edit';
+       const ACTION_END        = 'auction_end';
+       const ACTION_RESERVE_NOT_MET = 'reserve_not_met';
+       const ACTION_RELIST     = 'relist';
 
 	public static function log_suspend( $auction_id ) {
 		self::insert_log( $auction_id, self::ACTION_SUSPEND );
@@ -14,15 +17,28 @@ class WPAM_Admin_Log {
 		self::insert_log( $auction_id, self::ACTION_CANCEL );
 	}
 
-	public static function log_price_edit( $auction_id, $old_price, $new_price ) {
-		$details = wp_json_encode(
-			array(
-				'old_price' => $old_price,
-				'new_price' => $new_price,
-			)
-		);
-		self::insert_log( $auction_id, self::ACTION_PRICE_EDIT, $details );
-	}
+        public static function log_price_edit( $auction_id, $old_price, $new_price ) {
+                $details = wp_json_encode(
+                        array(
+                                'old_price' => $old_price,
+                                'new_price' => $new_price,
+                        )
+                );
+                self::insert_log( $auction_id, self::ACTION_PRICE_EDIT, $details );
+        }
+
+       public static function log_end( $auction_id, $reason = '' ) {
+               $details = $reason ? wp_json_encode( array( 'reason' => $reason ) ) : '';
+               self::insert_log( $auction_id, self::ACTION_END, $details );
+       }
+
+       public static function log_reserve_not_met( $auction_id ) {
+               self::insert_log( $auction_id, self::ACTION_RESERVE_NOT_MET );
+       }
+
+       public static function log_relist( $auction_id ) {
+               self::insert_log( $auction_id, self::ACTION_RELIST );
+       }
 
 	protected static function insert_log( $auction_id, $action, $details = '' ) {
 		global $wpdb;


### PR DESCRIPTION
## Summary
- track auction lifecycle events in `WPAM_Admin_Log`
- log these events when auctions end, fail reserve or get relisted
- document the Logs admin page

## Testing
- `php -l includes/class-wpam-admin-log.php`
- `php -l includes/class-wpam-auction.php`
- `php -l admin/class-wpam-logs-table.php`
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/test-audit-log.php` *(fails: Class "PHPUnit\TextUI\Command" not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b2d6ca6c883339ae9e71825b6a688