### PR TITLE
Fix auction max bids retrieval

### DIFF
--- a/includes/class-wpam-bid.php
+++ b/includes/class-wpam-bid.php
@@ -126,7 +126,7 @@ class WPAM_Bid {
             $new_lead_user = $user_id;
         }
 
-        $max_bids = intval( get_post_meta( $auction_id, '_auction_max_bids', 0 ) );
+        $max_bids = intval( get_post_meta( $auction_id, '_auction_max_bids', true ) );
         if ( $max_bids > 0 ) {
             $count = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $table WHERE auction_id = %d AND user_id = %d", $auction_id, $user_id ) );
             if ( $count >= $max_bids ) {
@@ -420,7 +420,7 @@ class WPAM_Bid {
             $max_bid = $bid;
         }
 
-        $max_bids = intval( get_post_meta( $auction_id, '_auction_max_bids', 0 ) );
+        $max_bids = intval( get_post_meta( $auction_id, '_auction_max_bids', true ) );
         if ( $max_bids > 0 ) {
             $count = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $table WHERE auction_id = %d AND user_id = %d", $auction_id, $user_id ) );
             if ( $count >= $max_bids ) {

--- a/tests/test-bid-limit.php
+++ b/tests/test-bid-limit.php
@@ -45,4 +45,34 @@ class Test_WPAM_Bid_Limit extends WP_Ajax_UnitTestCase {
         }
         $this->fail( 'Expected bid limit error' );
     }
+
+    public function test_multiple_bids_allowed_when_limit_greater_than_one() {
+        update_post_meta( $this->auction_id, '_auction_max_bids', 2 );
+
+        $_POST = [
+            'nonce'      => wp_create_nonce( 'wpam_place_bid' ),
+            'auction_id' => $this->auction_id,
+            'bid'        => 5,
+        ];
+        try {
+            $this->_handleAjax( 'wpam_place_bid' );
+        } catch ( WPAjaxDieContinueException $e ) {
+            // ignore first bid
+        }
+
+        $_POST = [
+            'nonce'      => wp_create_nonce( 'wpam_place_bid' ),
+            'auction_id' => $this->auction_id,
+            'bid'        => 6,
+        ];
+        try {
+            $this->_handleAjax( 'wpam_place_bid' );
+        } catch ( WPAjaxDieContinueException $e ) {
+            $response = json_decode( $this->_last_response, true );
+            $this->assertTrue( $response['success'] );
+            return;
+        }
+        $this->fail( 'Expected AJAX success' );
+    }
 }
+


### PR DESCRIPTION
## Summary
- fix retrieval of `_auction_max_bids` meta
- allow multiple bids when auction limit is higher than one
- add regression test for multiple bids

## Testing
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/test-bid-limit.php` *(fails: Class "PHPUnit\TextUI\Command" not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b378534cc8333a2adc55550587cd5