### PR TITLE
Add realtime bid status element

### DIFF
--- a/includes/api-integrations/class-pusher-provider.php
+++ b/includes/api-integrations/class-pusher-provider.php
@@ -76,12 +76,20 @@ class WPAM_Pusher_Provider implements WPAM_Realtime_Provider {
         $channel = $this->get_channel_name();
 
         if ( $channel ) {
+            global $wpdb;
+            $lead_user = intval( get_post_meta( $auction_id, '_auction_lead_user', true ) );
+            $bidders  = $wpdb->get_col( $wpdb->prepare( "SELECT DISTINCT user_id FROM {$wpdb->prefix}wc_auction_bids WHERE auction_id = %d", $auction_id ) );
+            $watchers = $wpdb->get_col( $wpdb->prepare( "SELECT DISTINCT user_id FROM {$wpdb->prefix}wc_auction_watchlists WHERE auction_id = %d", $auction_id ) );
+            $participants = count( array_unique( array_merge( $bidders, $watchers ) ) );
+
             $this->pusher->trigger(
                 $channel,
                 'bid_update',
                 [
-                    'auction_id' => $auction_id,
-                    'bid'        => $bid_amount,
+                    'auction_id'  => $auction_id,
+                    'bid'         => $bid_amount,
+                    'lead_user'   => $lead_user,
+                    'participants' => $participants,
                 ]
             );
         }

--- a/includes/class-wpam-html.php
+++ b/includes/class-wpam-html.php
@@ -60,6 +60,7 @@ class WPAM_HTML {
     echo '<p class="wpam-current-price">' . esc_html( $label ) .
          ' <span class="wpam-current-bid" data-auction-id="' . esc_attr( $auction_id ) . '">' .
          esc_html( $display_highest ) . '</span></p>';
+    echo '<div class="wpam-bid-status" data-auction-id="' . esc_attr( $auction_id ) . '"></div>';
 
     if ( $atts['showBidForm'] ) {
       echo '<form class="wpam-bid-form">';

--- a/templates/single-auction.php
+++ b/templates/single-auction.php
@@ -17,6 +17,7 @@ get_header();
             <?php _e( 'Place Bid', 'wpam' ); ?>
         </button>
     </form>
+    <div class="wpam-bid-status" data-auction-id="<?php the_ID(); ?>"></div>
     <?php wp_nonce_field( 'wpam_toggle_watchlist', 'wpam_watchlist_nonce', false ); ?>
     <button class="button wpam-watchlist-button" data-auction-id="<?php the_ID(); ?>">
         <?php _e( 'Toggle Watchlist', 'wpam' ); ?>


### PR DESCRIPTION
## Summary
- add persistent bid status element to templates and helper
- surface lead user and participant count via Pusher
- show live bid status text on page and update via AJAX and Pusher

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: displays usage)*
- `vendor/bin/phpcs includes/class-wpam-html.php templates/single-auction.php public/js/ajax-bid.js includes/api-integrations/class-pusher-provider.php -d memory_limit=1G` *(fails: coding standard errors)*

------
https://chatgpt.com/codex/tasks/task_e_688b5aeff5008333a95cdee776a16737