### PR TITLE
Implement Pusher presence viewer tracking

### DIFF
--- a/includes/api-integrations/class-realtime-provider.php
+++ b/includes/api-integrations/class-realtime-provider.php
@@ -3,4 +3,5 @@ namespace WPAM\Includes;
 
 interface WPAM_Realtime_Provider {
     public function send_bid_update( $auction_id, $bid_amount );
+    public function send_viewer_event( $auction_id, $action );
 }

--- a/includes/class-wpam-html.php
+++ b/includes/class-wpam-html.php
@@ -61,6 +61,8 @@ class WPAM_HTML {
          ' <span class="wpam-current-bid" data-auction-id="' . esc_attr( $auction_id ) . '">' .
          esc_html( $display_highest ) . '</span></p>';
     echo '<div class="wpam-bid-status" data-auction-id="' . esc_attr( $auction_id ) . '"></div>';
+    echo '<p>' . esc_html__( 'Viewers:', 'wpam' ) . ' <span class="wpam-viewer-count" data-auction-id="' . esc_attr( $auction_id ) . '">0</span></p>';
+    echo '<p>' . esc_html__( 'Participants:', 'wpam' ) . ' <span class="wpam-participant-count" data-auction-id="' . esc_attr( $auction_id ) . '">0</span></p>';
 
     if ( $atts['showBidForm'] ) {
       echo '<form class="wpam-bid-form">';

--- a/templates/single-auction.php
+++ b/templates/single-auction.php
@@ -18,6 +18,8 @@ get_header();
         </button>
     </form>
     <div class="wpam-bid-status" data-auction-id="<?php the_ID(); ?>"></div>
+    <p><?php esc_html_e( 'Viewers:', 'wpam' ); ?> <span class="wpam-viewer-count" data-auction-id="<?php the_ID(); ?>">0</span></p>
+    <p><?php esc_html_e( 'Participants:', 'wpam' ); ?> <span class="wpam-participant-count" data-auction-id="<?php the_ID(); ?>">0</span></p>
     <?php wp_nonce_field( 'wpam_toggle_watchlist', 'wpam_watchlist_nonce', false ); ?>
     <button class="button wpam-watchlist-button" data-auction-id="<?php the_ID(); ?>">
         <?php _e( 'Toggle Watchlist', 'wpam' ); ?>


### PR DESCRIPTION
## Summary
- add presence viewer events to Pusher provider
- expose Pusher auth endpoints in public class
- update ajax-bid JS to authenticate presence channel and track viewers
- display viewer/participant counts in templates
- extend realtime provider interface

## Testing
- `composer install`
- `vendor/bin/phpunit tests` *(no tests found)*
- `vendor/bin/phpcs includes/api-integrations/class-pusher-provider.php public/class-wpam-public.php public/js/ajax-bid.js templates/single-auction.php includes/class-wpam-html.php`

------
https://chatgpt.com/codex/tasks/task_e_688b61520bac8333b951693a7ae84481