### PR TITLE
Add event bus for bid events

### DIFF
--- a/includes/class-wpam-event-bus.php
+++ b/includes/class-wpam-event-bus.php
@@ -1,0 +1,35 @@
+<?php
+namespace WPAM\Includes;
+
+/**
+ * Simple event bus to broadcast events to registered providers.
+ */
+class WPAM_Event_Bus {
+    /** @var array */
+    protected static $listeners = [];
+
+    /**
+     * Register a provider/listener with the event bus.
+     *
+     * @param object $listener Listener implementing handle_event method.
+     */
+    public static function register( $listener ) {
+        if ( is_object( $listener ) ) {
+            self::$listeners[] = $listener;
+        }
+    }
+
+    /**
+     * Dispatch an event to all registered listeners.
+     *
+     * @param string $event   Event name.
+     * @param array  $payload Event payload.
+     */
+    public static function dispatch( $event, $payload = [] ) {
+        foreach ( self::$listeners as $listener ) {
+            if ( method_exists( $listener, 'handle_event' ) ) {
+                $listener->handle_event( $event, $payload );
+            }
+        }
+    }
+}

--- a/includes/class-wpam-loader.php
+++ b/includes/class-wpam-loader.php
@@ -9,6 +9,13 @@ class WPAM_Loader {
         }
 
         // Init classes
+        // Register event listeners
+        WPAM_Event_Bus::register( new WPAM_Notifications() );
+        $pusher_provider = new WPAM_Pusher_Provider();
+        if ( $pusher_provider->is_active() ) {
+            WPAM_Event_Bus::register( $pusher_provider );
+        }
+
         new WPAM_Auction();
         new WPAM_Bid();
         new WPAM_Watchlist();


### PR DESCRIPTION
## Summary
- implement `WPAM_Event_Bus` for broadcasting events
- allow `WPAM_Pusher_Provider` and `WPAM_Notifications` to handle dispatched events
- register listeners on plugin load
- dispatch events from bidding logic instead of calling providers directly

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: Could not load XML from empty string)*
- `vendor/bin/phpcs -n --standard=phpcs.xml` *(fails: must supply a file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688b695714648333837d1d00b2cf7f1f