### PR TITLE
Add realtime auction events

### DIFF
--- a/includes/api-integrations/class-realtime-provider.php
+++ b/includes/api-integrations/class-realtime-provider.php
@@ -4,4 +4,7 @@ namespace WPAM\Includes;
 interface WPAM_Realtime_Provider {
     public function send_bid_update( $auction_id, $bid_amount );
     public function send_viewer_event( $auction_id, $action );
+    public function trigger_bid_placed( $auction_id, $user_id, $amount );
+    public function trigger_user_outbid( $auction_id, $user_id );
+    public function trigger_auction_status( $auction_id, $status, $reason = '' );
 }

--- a/public/js/ajax-bid.js
+++ b/public/js/ajax-bid.js
@@ -235,7 +235,30 @@ jQuery(function ($) {
 
         const lead = data.lead_user ? parseInt(data.lead_user, 10) : 0;
         checkBidStatus(data.auction_id, parseFloat(data.bid), lead);
+      });
+      channel.bind('bid_placed', function (data) {
+        if (!data || !data.auction_id || !data.amount) return;
+        const el = $('.wpam-current-bid[data-auction-id="' + data.auction_id + '"]');
+        el.text(data.amount);
+        if (typeof data.participants !== 'undefined') {
+          $('.wpam-participant-count[data-auction-id="' + data.auction_id + '"]').text(data.participants);
+        }
+        const lead = data.lead_user ? parseInt(data.lead_user, 10) : 0;
+        checkBidStatus(data.auction_id, parseFloat(data.amount), lead);
         showToast(i18n.outbid || 'A new bid has been placed');
+      });
+      channel.bind('user_outbid', function (data) {
+        if (!data || !data.auction_id || !data.user_id) return;
+        const currentUser = parseInt(wpam_ajax.current_user_id, 10);
+        if (currentUser && currentUser === parseInt(data.user_id, 10)) {
+          showToast(i18n.outbid || "You've been outbid", 'warning');
+        }
+      });
+      channel.bind('auction_status', function (data) {
+        if (!data || !data.status) return;
+        if (data.status === 'ended') {
+          showToast(i18n.auction_ended || 'Auction ended', 'info');
+        }
       });
       const presence = pusher.subscribe('presence-auction-' + auctionId);
       const updateViewers = function () {


### PR DESCRIPTION
## Summary
- add new realtime methods to WPAM_Realtime_Provider
- broadcast `bid_placed`, `user_outbid` and `auction_status` via Pusher
- dispatch auction status changes from auction model
- subscribe to new events on the frontend

## Testing
- `vendor/bin/phpcs --standard=phpcs.xml includes/api-integrations/class-pusher-provider.php includes/api-integrations/class-realtime-provider.php includes/class-wpam-auction.php`
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/test-bid.php` *(fails: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_688b724048d0833385ad12d7559fa545