### PR TITLE
Add user status to bid events

### DIFF
--- a/includes/api-integrations/class-realtime-provider.php
+++ b/includes/api-integrations/class-realtime-provider.php
@@ -2,9 +2,9 @@
 namespace WPAM\Includes;
 
 interface WPAM_Realtime_Provider {
-    public function send_bid_update( $auction_id, $bid_amount );
+    public function send_bid_update( $auction_id, $bid_amount, $statuses = [] );
     public function send_viewer_event( $auction_id, $action );
-    public function trigger_bid_placed( $auction_id, $user_id, $amount );
+    public function trigger_bid_placed( $auction_id, $user_id, $amount, $statuses = [] );
     public function trigger_user_outbid( $auction_id, $user_id );
     public function trigger_auction_status( $auction_id, $status, $reason = '' );
 }


### PR DESCRIPTION
## Summary
- compute per-user status after each bid
- expose status in AJAX/REST bid responses
- propagate statuses through realtime providers
- show server-supplied status messages in ajax-bid.js

## Testing
- `php -l includes/class-wpam-bid.php`
- `php -l includes/api-integrations/class-pusher-provider.php`
- `php -l includes/api-integrations/class-realtime-provider.php`
- `./vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/test-bid.php --testdox --colors=never` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_688b7435c70c83339742d38721b5d50a