### PR TITLE
Fix duplicate max_reached logic

### DIFF
--- a/includes/class-wpam-bid.php
+++ b/includes/class-wpam-bid.php
@@ -312,11 +312,6 @@ class WPAM_Bid {
             $max_reached = true;
         }
 
-        $max_reached = false;
-        if ( $proxy_enabled && $max_bid <= $new_highest && $new_highest_user !== $user_id ) {
-            $max_reached = true;
-        }
-
 
         // Dispatch standardized events
         WPAM_Event_Bus::dispatch( 'bid_placed', [


### PR DESCRIPTION
## Summary
- remove redundant `max_reached` block in bid logic

## Testing
- `php vendor/bin/phpunit tests/test-bid.php` *(fails: Class "WP_Ajax_UnitTestCase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b7c6e9d5c833389be1c31e52da4bd