### PR TITLE
Add DataTables-powered admin tables

### DIFF
--- a/admin/js/admin-tables.js
+++ b/admin/js/admin-tables.js
@@ -1,0 +1,45 @@
+jQuery(
+	function ($) {
+		if ( $( '#wpam-auctions-table' ).length ) {
+			$( '#wpam-auctions-table' ).DataTable(
+				{
+					ajax: {
+						url: wpamTables.auctions_endpoint,
+						beforeSend: function (xhr) {
+							xhr.setRequestHeader( 'X-WP-Nonce', wpamTables.nonce ); },
+						dataSrc: 'data'
+					},
+					paging: true,
+					searching: true,
+					columns: [
+					{ data: 'title' },
+					{ data: 'start' },
+					{ data: 'end' },
+					{ data: 'state' },
+					{ data: 'reason' }
+					]
+				}
+			);
+		}
+		if ( $( '#wpam-bids-table' ).length ) {
+			var endpoint = wpamTables.bids_endpoint + '?auction_id=' + wpamTables.auction_id;
+			$( '#wpam-bids-table' ).DataTable(
+				{
+					ajax: {
+						url: endpoint,
+						beforeSend: function (xhr) {
+							xhr.setRequestHeader( 'X-WP-Nonce', wpamTables.nonce ); },
+						dataSrc: 'data'
+					},
+					paging: true,
+					searching: true,
+					columns: [
+					{ data: 'user' },
+					{ data: 'amount' },
+					{ data: 'bid_time' }
+					]
+				}
+			);
+		}
+	}
+);

--- a/includes/class-wpam-admin-rest.php
+++ b/includes/class-wpam-admin-rest.php
@@ -1,0 +1,113 @@
+<?php
+namespace WPAM\Includes;
+
+class WPAM_Admin_Rest {
+	public static function get_auctions( \WP_REST_Request $request ) {
+		$search   = sanitize_text_field( $request->get_param( 'search' ) );
+		$status   = sanitize_text_field( $request->get_param( 'status' ) );
+		$type     = sanitize_text_field( $request->get_param( 'type' ) );
+		$page     = max( 1, intval( $request->get_param( 'page' ) ) );
+		$per_page = max( 1, intval( $request->get_param( 'per_page' ) ) );
+		$args     = array(
+			'post_type'      => 'product',
+			'posts_per_page' => $per_page ?: 20,
+			'paged'          => $page,
+			's'              => $search,
+			'tax_query'      => array(
+				array(
+					'taxonomy' => 'product_type',
+					'field'    => 'slug',
+					'terms'    => 'auction',
+				),
+			),
+			'meta_query'     => array(),
+		);
+		$now      = wp_date( 'Y-m-d H:i:s', current_datetime()->getTimestamp(), wp_timezone() );
+		if ( $type ) {
+			$args['meta_query'][] = array(
+				'key'   => '_auction_type',
+				'value' => $type,
+			);
+		}
+		if ( 'upcoming' === $status ) {
+			$args['meta_query'][] = array(
+				'key'     => '_auction_start',
+				'value'   => $now,
+				'compare' => '>',
+				'type'    => 'DATETIME',
+			);
+		} elseif ( 'ended' === $status ) {
+			$args['meta_query'][] = array(
+				'key'     => '_auction_end',
+				'value'   => $now,
+				'compare' => '<',
+				'type'    => 'DATETIME',
+			);
+		} elseif ( 'active' === $status ) {
+			$args['meta_query'][] = array(
+				'key'     => '_auction_start',
+				'value'   => $now,
+				'compare' => '<=',
+				'type'    => 'DATETIME',
+			);
+			$args['meta_query'][] = array(
+				'key'     => '_auction_end',
+				'value'   => $now,
+				'compare' => '>=',
+				'type'    => 'DATETIME',
+			);
+		}
+		$query = new \WP_Query( $args );
+		$items = array();
+		foreach ( $query->posts as $post ) {
+			$items[] = array(
+				'ID'     => $post->ID,
+				'title'  => $post->post_title,
+				'start'  => get_post_meta( $post->ID, '_auction_start', true ),
+				'end'    => get_post_meta( $post->ID, '_auction_end', true ),
+				'state'  => get_post_meta( $post->ID, '_auction_state', true ),
+				'reason' => get_post_meta( $post->ID, '_auction_ending_reason', true ),
+			);
+		}
+		return rest_ensure_response(
+			array(
+				'total' => $query->found_posts,
+				'data'  => $items,
+			)
+		);
+	}
+
+	public static function get_bids( \WP_REST_Request $request ) {
+		global $wpdb;
+		$auction_id = absint( $request->get_param( 'auction_id' ) );
+		if ( ! $auction_id ) {
+			return rest_ensure_response(
+				array(
+					'total' => 0,
+					'data'  => array(),
+				)
+			);
+		}
+		$per_page = max( 1, intval( $request->get_param( 'per_page' ) ) );
+		$page     = max( 1, intval( $request->get_param( 'page' ) ) );
+		$offset   = ( $page - 1 ) * $per_page;
+		$table    = $wpdb->prefix . 'wc_auction_bids';
+		$rows     = $wpdb->get_results( $wpdb->prepare( "SELECT SQL_CALC_FOUND_ROWS * FROM $table WHERE auction_id = %d ORDER BY bid_time DESC LIMIT %d OFFSET %d", $auction_id, $per_page, $offset ), ARRAY_A );
+		$total    = $wpdb->get_var( 'SELECT FOUND_ROWS()' );
+		$data     = array();
+		foreach ( $rows as $row ) {
+			$user   = get_user_by( 'id', $row['user_id'] );
+			$data[] = array(
+				'user'     => $user ? $user->display_name : sprintf( '#%d', $row['user_id'] ),
+				'amount'   => $row['bid_amount'],
+				'bid_time' => $row['bid_time'],
+			);
+		}
+		return rest_ensure_response(
+			array(
+				'total' => intval( $total ),
+				'data'  => $data,
+			)
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- expose `/wpam/v1/auctions` and `/wpam/v1/bids` REST API endpoints
- load DataTables on auctions and bids admin pages
- render auctions and bids tables using DataTables

## Testing
- `composer install`
- `vendor/bin/phpunit -c tests` *(fails: Could not load XML from empty string)*
- `npm run build` *(fails: wp-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b84a5efb08333a3cbab526860cb6d