### PR TITLE
Replace DataTables with Gutenberg components

### DIFF
--- a/admin/class-wpam-admin.php
+++ b/admin/class-wpam-admin.php
@@ -397,14 +397,7 @@ class WPAM_Admin {
 	public function render_auctions_page() {
                echo '<div class="wrap">';
                echo '<h1>' . esc_html__( 'Auctions', 'wpam' ) . '</h1>';
-               echo '<table id="wpam-auctions-table" class="wp-list-table widefat striped">';
-               echo '<thead><tr>';
-               echo '<th>' . esc_html__( 'Auction', 'wpam' ) . '</th>';
-               echo '<th>' . esc_html__( 'Start', 'wpam' ) . '</th>';
-               echo '<th>' . esc_html__( 'End', 'wpam' ) . '</th>';
-               echo '<th>' . esc_html__( 'State', 'wpam' ) . '</th>';
-               echo '<th>' . esc_html__( 'Ending Reason', 'wpam' ) . '</th>';
-               echo '</tr></thead><tbody></tbody></table>';
+               echo '<div id="wpam-auctions-root"></div>';
                echo '</div>';
 	}
 
@@ -418,12 +411,7 @@ class WPAM_Admin {
 			return;
 		}
                echo '<h1>' . sprintf( esc_html__( 'Bids for Auction #%d', 'wpam' ), $auction_id ) . '</h1>';
-               echo '<table id="wpam-bids-table" class="wp-list-table widefat striped">';
-               echo '<thead><tr>';
-               echo '<th>' . esc_html__( 'User', 'wpam' ) . '</th>';
-               echo '<th>' . esc_html__( 'Amount', 'wpam' ) . '</th>';
-               echo '<th>' . esc_html__( 'Bid Time', 'wpam' ) . '</th>';
-               echo '</tr></thead><tbody></tbody></table>';
+               echo '<div id="wpam-bids-root"></div>';
                echo '</div>';
         }
 
@@ -439,38 +427,25 @@ class WPAM_Admin {
 			echo '<div class="updated"><p>' . esc_html__( 'Message updated.', 'wpam' ) . '</p></div>';
 		}
 
-		$table = new WPAM_Messages_Table();
-		$table->prepare_items();
-		echo '<div class="wrap">';
-		echo '<h1>' . esc_html__( 'Auction Messages', 'wpam' ) . '</h1>';
-		echo '<form method="get">';
-		echo '<input type="hidden" name="page" value="wpam-messages" />';
-		$table->search_box( __( 'Search Messages', 'wpam' ), 'message-search' );
-		$table->display();
-		echo '</form></div>';
-	}
+                echo '<div class="wrap">';
+                echo '<h1>' . esc_html__( 'Auction Messages', 'wpam' ) . '</h1>';
+                echo '<div id="wpam-messages-root"></div>';
+                echo '</div>';
+        }
 
-	public function render_logs_page() {
-		$table = new WPAM_Logs_Table();
-		$table->prepare_items();
-		echo '<div class="wrap">';
-		echo '<h1>' . esc_html__( 'Admin Logs', 'wpam' ) . '</h1>';
-		echo '<form method="get">';
-		echo '<input type="hidden" name="page" value="wpam-logs" />';
-		$table->display();
-		echo '</form></div>';
-	}
+        public function render_logs_page() {
+                echo '<div class="wrap">';
+                echo '<h1>' . esc_html__( 'Admin Logs', 'wpam' ) . '</h1>';
+                echo '<div id="wpam-logs-root"></div>';
+                echo '</div>';
+        }
 
-	public function render_flagged_page() {
-		$table = new WPAM_Flagged_Table();
-		$table->prepare_items();
-		echo '<div class="wrap">';
-		echo '<h1>' . esc_html__( 'Flagged Users', 'wpam' ) . '</h1>';
-		echo '<form method="get">';
-		echo '<input type="hidden" name="page" value="wpam-flagged" />';
-		$table->display();
-		echo '</form></div>';
-	}
+        public function render_flagged_page() {
+                echo '<div class="wrap">';
+                echo '<h1>' . esc_html__( 'Flagged Users', 'wpam' ) . '</h1>';
+                echo '<div id="wpam-flagged-root"></div>';
+                echo '</div>';
+        }
 
 	public function enqueue_scripts( $hook ) {
 		$screen = get_current_screen();
@@ -534,15 +509,33 @@ class WPAM_Admin {
                         );
                 }
 
-                if ( in_array( $hook, array( 'toplevel_page_wpam-' . $slug, $slug . '_page_wpam-auctions', $slug . '_page_wpam-bids' ), true ) ) {
-                        wp_enqueue_style( 'wpam-datatables', 'https://cdn.datatables.net/1.13.4/css/jquery.dataTables.min.css', array(), '1.13.4' );
-                        wp_enqueue_script( 'wpam-datatables', 'https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js', array( 'jquery' ), '1.13.4', true );
-                        wp_enqueue_script( 'wpam-admin-tables', WPAM_PLUGIN_URL . 'admin/js/admin-tables.js', array( 'jquery', 'wpam-datatables' ), WPAM_PLUGIN_VERSION, true );
+                if ( in_array( $hook, array( 'toplevel_page_wpam-' . $slug, $slug . '_page_wpam-auctions', $slug . '_page_wpam-bids', $slug . '_page_wpam-messages', $slug . '_page_wpam-logs', $slug . '_page_wpam-flagged' ), true ) ) {
+                        wp_enqueue_script( 'wpam-admin-tables', WPAM_PLUGIN_URL . 'admin/js/admin-tables.js', array( 'wp-element', 'wp-components', 'wp-api-fetch' ), WPAM_PLUGIN_VERSION, true );
                         wp_localize_script( 'wpam-admin-tables', 'wpamTables', array(
                                 'nonce'             => wp_create_nonce( 'wp_rest' ),
                                 'auctions_endpoint' => rest_url( 'wpam/v1/auctions' ),
                                 'bids_endpoint'     => rest_url( 'wpam/v1/bids' ),
+                                'messages_endpoint' => rest_url( 'wpam/v1/messages' ),
+                                'logs_endpoint'     => rest_url( 'wpam/v1/logs' ),
+                                'flagged_endpoint'  => rest_url( 'wpam/v1/flagged' ),
                                 'auction_id'        => isset( $_GET['auction_id'] ) ? absint( $_GET['auction_id'] ) : 0,
+                                'i18n'              => array(
+                                        'auction'     => __( 'Auction', 'wpam' ),
+                                        'start'       => __( 'Start', 'wpam' ),
+                                        'end'         => __( 'End', 'wpam' ),
+                                        'state'       => __( 'State', 'wpam' ),
+                                        'reason'      => __( 'Ending Reason', 'wpam' ),
+                                        'user'        => __( 'User', 'wpam' ),
+                                        'amount'      => __( 'Amount', 'wpam' ),
+                                        'bid_time'    => __( 'Bid Time', 'wpam' ),
+                                        'message'     => __( 'Message', 'wpam' ),
+                                        'status'      => __( 'Status', 'wpam' ),
+                                        'date'        => __( 'Date', 'wpam' ),
+                                        'admin'       => __( 'Admin', 'wpam' ),
+                                        'action'      => __( 'Action', 'wpam' ),
+                                        'details'     => __( 'Details', 'wpam' ),
+                                        'reason_user' => __( 'Reason', 'wpam' ),
+                                ),
                         ) );
                 }
 
@@ -709,6 +702,42 @@ class WPAM_Admin {
                         array(
                                 'methods'             => \WP_REST_Server::READABLE,
                                 'callback'            => array( '\\WPAM\\Includes\\WPAM_Admin_Rest', 'get_bids' ),
+                                'permission_callback' => function () {
+                                        return current_user_can( 'manage_options' );
+                                },
+                        )
+                );
+
+                register_rest_route(
+                        'wpam/v1',
+                        '/messages',
+                        array(
+                                'methods'             => \WP_REST_Server::READABLE,
+                                'callback'            => array( '\\WPAM\\Includes\\WPAM_Admin_Rest', 'get_messages' ),
+                                'permission_callback' => function () {
+                                        return current_user_can( 'manage_options' );
+                                },
+                        )
+                );
+
+                register_rest_route(
+                        'wpam/v1',
+                        '/logs',
+                        array(
+                                'methods'             => \WP_REST_Server::READABLE,
+                                'callback'            => array( '\\WPAM\\Includes\\WPAM_Admin_Rest', 'get_logs' ),
+                                'permission_callback' => function () {
+                                        return current_user_can( 'manage_options' );
+                                },
+                        )
+                );
+
+                register_rest_route(
+                        'wpam/v1',
+                        '/flagged',
+                        array(
+                                'methods'             => \WP_REST_Server::READABLE,
+                                'callback'            => array( '\\WPAM\\Includes\\WPAM_Admin_Rest', 'get_flagged' ),
                                 'permission_callback' => function () {
                                         return current_user_can( 'manage_options' );
                                 },

--- a/admin/js/admin-tables.js
+++ b/admin/js/admin-tables.js
@@ -1,45 +1,94 @@
-jQuery(
-	function ($) {
-		if ( $( '#wpam-auctions-table' ).length ) {
-			$( '#wpam-auctions-table' ).DataTable(
-				{
-					ajax: {
-						url: wpamTables.auctions_endpoint,
-						beforeSend: function (xhr) {
-							xhr.setRequestHeader( 'X-WP-Nonce', wpamTables.nonce ); },
-						dataSrc: 'data'
-					},
-					paging: true,
-					searching: true,
-					columns: [
-					{ data: 'title' },
-					{ data: 'start' },
-					{ data: 'end' },
-					{ data: 'state' },
-					{ data: 'reason' }
-					]
-				}
-			);
-		}
-		if ( $( '#wpam-bids-table' ).length ) {
-			var endpoint = wpamTables.bids_endpoint + '?auction_id=' + wpamTables.auction_id;
-			$( '#wpam-bids-table' ).DataTable(
-				{
-					ajax: {
-						url: endpoint,
-						beforeSend: function (xhr) {
-							xhr.setRequestHeader( 'X-WP-Nonce', wpamTables.nonce ); },
-						dataSrc: 'data'
-					},
-					paging: true,
-					searching: true,
-					columns: [
-					{ data: 'user' },
-					{ data: 'amount' },
-					{ data: 'bid_time' }
-					]
-				}
-			);
-		}
-	}
-);
+(function( wp ) {
+    const { createElement, useEffect, useState } = wp.element;
+    const { Table, Spinner } = wp.components;
+    const { render } = wp.element;
+    const apiFetch = wp.apiFetch;
+
+    function DataTableApp( { endpoint, columns } ) {
+        const [ rows, setRows ] = useState( [] );
+        const [ loading, setLoading ] = useState( true );
+
+        useEffect( () => {
+            apiFetch( { path: endpoint, headers: { 'X-WP-Nonce': wpamTables.nonce } } ).then( ( res ) => {
+                setRows( res.data || [] );
+                setLoading( false );
+            } );
+        }, [ endpoint ] );
+
+        if ( loading ) {
+            return createElement( Spinner, null );
+        }
+
+        return createElement(
+            Table,
+            { className: 'wpam-table' },
+            createElement(
+                'thead',
+                null,
+                createElement(
+                    'tr',
+                    null,
+                    columns.map( ( col ) => createElement( 'th', { key: col.key }, col.label ) )
+                )
+            ),
+            createElement(
+                'tbody',
+                null,
+                rows.map( ( row, index ) =>
+                    createElement(
+                        'tr',
+                        { key: index },
+                        columns.map( ( col ) => createElement( 'td', { key: col.key }, row[ col.key ] ) )
+                    )
+                )
+            )
+        );
+    }
+
+    function mount( id, endpoint, columns ) {
+        const root = document.getElementById( id );
+        if ( root ) {
+            render( createElement( DataTableApp, { endpoint, columns } ), root );
+        }
+    }
+
+    document.addEventListener( 'DOMContentLoaded', function () {
+        mount( 'wpam-auctions-root', wpamTables.auctions_endpoint, [
+            { key: 'title', label: wpamTables.i18n.auction },
+            { key: 'start', label: wpamTables.i18n.start },
+            { key: 'end', label: wpamTables.i18n.end },
+            { key: 'state', label: wpamTables.i18n.state },
+            { key: 'reason', label: wpamTables.i18n.reason },
+        ] );
+
+        if ( wpamTables.auction_id ) {
+            mount( 'wpam-bids-root', wpamTables.bids_endpoint + '?auction_id=' + wpamTables.auction_id, [
+                { key: 'user', label: wpamTables.i18n.user },
+                { key: 'amount', label: wpamTables.i18n.amount },
+                { key: 'bid_time', label: wpamTables.i18n.bid_time },
+            ] );
+        }
+
+        mount( 'wpam-messages-root', wpamTables.messages_endpoint, [
+            { key: 'auction', label: wpamTables.i18n.auction },
+            { key: 'user', label: wpamTables.i18n.user },
+            { key: 'message', label: wpamTables.i18n.message },
+            { key: 'status', label: wpamTables.i18n.status },
+            { key: 'date', label: wpamTables.i18n.date },
+        ] );
+
+        mount( 'wpam-logs-root', wpamTables.logs_endpoint, [
+            { key: 'auction', label: wpamTables.i18n.auction },
+            { key: 'admin', label: wpamTables.i18n.admin },
+            { key: 'action', label: wpamTables.i18n.action },
+            { key: 'details', label: wpamTables.i18n.details },
+            { key: 'date', label: wpamTables.i18n.date },
+        ] );
+
+        mount( 'wpam-flagged-root', wpamTables.flagged_endpoint, [
+            { key: 'user', label: wpamTables.i18n.user },
+            { key: 'reason', label: wpamTables.i18n.reason_user },
+            { key: 'flagged_at', label: wpamTables.i18n.date },
+        ] );
+    } );
+})( window.wp );

--- a/includes/class-wpam-admin-rest.php
+++ b/includes/class-wpam-admin-rest.php
@@ -77,7 +77,7 @@ class WPAM_Admin_Rest {
 		);
 	}
 
-	public static function get_bids( \WP_REST_Request $request ) {
+        public static function get_bids( \WP_REST_Request $request ) {
 		global $wpdb;
 		$auction_id = absint( $request->get_param( 'auction_id' ) );
 		if ( ! $auction_id ) {
@@ -103,11 +103,112 @@ class WPAM_Admin_Rest {
 				'bid_time' => $row['bid_time'],
 			);
 		}
-		return rest_ensure_response(
-			array(
-				'total' => intval( $total ),
-				'data'  => $data,
-			)
-		);
-	}
+                return rest_ensure_response(
+                        array(
+                                'total' => intval( $total ),
+                                'data'  => $data,
+                        )
+                );
+        }
+
+        public static function get_messages( \WP_REST_Request $request ) {
+                global $wpdb;
+                $table     = $wpdb->prefix . 'wc_auction_messages';
+                $per_page  = max( 1, intval( $request->get_param( 'per_page' ) ) );
+                $page      = max( 1, intval( $request->get_param( 'page' ) ) );
+                $offset    = ( $page - 1 ) * $per_page;
+                $search    = sanitize_text_field( $request->get_param( 'search' ) );
+
+                $where = '';
+                $args  = array();
+                if ( $search ) {
+                        $where = ' WHERE message LIKE %s';
+                        $args[] = '%' . $wpdb->esc_like( $search ) . '%';
+                }
+
+                $sql   = "SELECT SQL_CALC_FOUND_ROWS * FROM $table" . $where . ' ORDER BY created_at DESC LIMIT %d OFFSET %d';
+                $args[] = $per_page;
+                $args[] = $offset;
+                $rows  = $wpdb->get_results( $wpdb->prepare( $sql, ...$args ), ARRAY_A );
+                $total = $wpdb->get_var( 'SELECT FOUND_ROWS()' );
+
+                $data = array();
+                foreach ( $rows as $row ) {
+                        $user = get_user_by( 'id', $row['user_id'] );
+                        $data[] = array(
+                                'auction' => get_the_title( $row['auction_id'] ) ?: sprintf( '#%d', $row['auction_id'] ),
+                                'user'    => $user ? $user->display_name : sprintf( '#%d', $row['user_id'] ),
+                                'message' => $row['message'],
+                                'status'  => $row['approved'] ? __( 'Approved', 'wpam' ) : __( 'Pending', 'wpam' ),
+                                'date'    => $row['created_at'],
+                        );
+                }
+
+                return rest_ensure_response(
+                        array(
+                                'total' => intval( $total ),
+                                'data'  => $data,
+                        )
+                );
+        }
+
+        public static function get_logs( \WP_REST_Request $request ) {
+                global $wpdb;
+                $table    = $wpdb->prefix . 'wc_auction_logs';
+                $per_page = max( 1, intval( $request->get_param( 'per_page' ) ) );
+                $page     = max( 1, intval( $request->get_param( 'page' ) ) );
+                $offset   = ( $page - 1 ) * $per_page;
+                $rows     = $wpdb->get_results( $wpdb->prepare( "SELECT SQL_CALC_FOUND_ROWS * FROM $table ORDER BY logged_at DESC LIMIT %d OFFSET %d", $per_page, $offset ), ARRAY_A );
+                $total    = $wpdb->get_var( 'SELECT FOUND_ROWS()' );
+
+                $data = array();
+                foreach ( $rows as $row ) {
+                        $admin = get_user_by( 'id', $row['admin_id'] );
+                        $details = maybe_unserialize( $row['details'] );
+                        if ( is_array( $details ) ) {
+                                $details = wp_json_encode( $details );
+                        }
+                        $data[] = array(
+                                'auction' => get_the_title( $row['auction_id'] ) ?: sprintf( '#%d', $row['auction_id'] ),
+                                'admin'   => $admin ? $admin->display_name : sprintf( '#%d', $row['admin_id'] ),
+                                'action'  => $row['action'],
+                                'details' => $details,
+                                'date'    => $row['logged_at'],
+                        );
+                }
+
+                return rest_ensure_response(
+                        array(
+                                'total' => intval( $total ),
+                                'data'  => $data,
+                        )
+                );
+        }
+
+        public static function get_flagged( \WP_REST_Request $request ) {
+                global $wpdb;
+                $table    = $wpdb->prefix . 'wpam_flagged_users';
+                $per_page = max( 1, intval( $request->get_param( 'per_page' ) ) );
+                $page     = max( 1, intval( $request->get_param( 'page' ) ) );
+                $offset   = ( $page - 1 ) * $per_page;
+                $rows     = $wpdb->get_results( $wpdb->prepare( "SELECT SQL_CALC_FOUND_ROWS * FROM $table ORDER BY flagged_at DESC LIMIT %d OFFSET %d", $per_page, $offset ), ARRAY_A );
+                $total    = $wpdb->get_var( 'SELECT FOUND_ROWS()' );
+
+                $data = array();
+                foreach ( $rows as $row ) {
+                        $user = get_user_by( 'id', $row['user_id'] );
+                        $data[] = array(
+                                'user'       => $user ? $user->display_name : sprintf( '#%d', $row['user_id'] ),
+                                'reason'     => $row['reason'],
+                                'flagged_at' => $row['flagged_at'],
+                        );
+                }
+
+                return rest_ensure_response(
+                        array(
+                                'total' => intval( $total ),
+                                'data'  => $data,
+                        )
+                );
+        }
 }


### PR DESCRIPTION
## Summary
- swap jQuery DataTables admin tables for React tables
- render containers for Auctions, Bids, Messages, Logs and Flagged pages
- load new script with REST endpoints for all tables
- expose REST endpoints for messages, logs and flagged users

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: shows help output)*
- `vendor/bin/phpcs admin/class-wpam-admin.php includes/class-wpam-admin-rest.php admin/js/admin-tables.js` *(fails: coding standard errors)*

------
https://chatgpt.com/codex/tasks/task_e_688b8de419a083339127f15b36889caa