### PR TITLE
Add admin layout with sticky header

### DIFF
--- a/clients/src/App.jsx
+++ b/clients/src/App.jsx
@@ -4,15 +4,16 @@ import {
   MemoryRouter,
   useNavigate,
   useLocation,
-} from 'react-router-dom';
-import { useEffect } from 'react';
-import highlightSubmenu from '@/lib/highlightSubmenu';
-import AllAuctions from './pages/AllAuctions.jsx';
-import Bids from './pages/Bids.jsx';
-import Messages from './pages/Messages.jsx';
-import Logs from './pages/Logs.jsx';
-import FlaggedUsers from './pages/FlaggedUsers.jsx';
-import Settings from './pages/Settings.jsx';
+} from "react-router-dom";
+import { useEffect } from "react";
+import highlightSubmenu from "@/lib/highlightSubmenu";
+import AdminLayout from "@/components/layout/AdminLayout.jsx";
+import AllAuctions from "./pages/AllAuctions.jsx";
+import Bids from "./pages/Bids.jsx";
+import Messages from "./pages/Messages.jsx";
+import Logs from "./pages/Logs.jsx";
+import FlaggedUsers from "./pages/FlaggedUsers.jsx";
+import Settings from "./pages/Settings.jsx";
 
 function AppRoutes() {
   const navigate = useNavigate();
@@ -20,31 +21,33 @@ function AppRoutes() {
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
-    const path = params.get('path') || '/all-auctions';
+    const path = params.get("path") || "/all-auctions";
     navigate(path, { replace: true });
   }, [navigate]);
 
   useEffect(() => {
     const newUrl = `admin.php?page=wpam-auctions&path=${location.pathname}`;
-    window.history.replaceState({}, '', newUrl);
+    window.history.replaceState({}, "", newUrl);
     highlightSubmenu(location.pathname);
   }, [location]);
 
   return (
-    <Routes>
-      <Route path="/all-auctions" element={<AllAuctions />} />
-      <Route path="/bids" element={<Bids />} />
-      <Route path="/messages" element={<Messages />} />
-      <Route path="/logs" element={<Logs />} />
-      <Route path="/flagged-users" element={<FlaggedUsers />} />
-      <Route path="/settings" element={<Settings />} />
-    </Routes>
+    <AdminLayout>
+      <Routes>
+        <Route path="/all-auctions" element={<AllAuctions />} />
+        <Route path="/bids" element={<Bids />} />
+        <Route path="/messages" element={<Messages />} />
+        <Route path="/logs" element={<Logs />} />
+        <Route path="/flagged-users" element={<FlaggedUsers />} />
+        <Route path="/settings" element={<Settings />} />
+      </Routes>
+    </AdminLayout>
   );
 }
 
 export default function App() {
   const params = new URLSearchParams(window.location.search);
-  const initialPath = params.get('path') || '/all-auctions';
+  const initialPath = params.get("path") || "/all-auctions";
   return (
     <MemoryRouter initialEntries={[initialPath]}>
       <AppRoutes />

--- a/clients/src/components/layout/AdminLayout.jsx
+++ b/clients/src/components/layout/AdminLayout.jsx
@@ -1,0 +1,28 @@
+import { Link, useLocation } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+
+export default function AdminLayout({ children }) {
+  const location = useLocation();
+  const navItems = [
+    { label: "All Auctions", path: "/all-auctions" },
+    { label: "Settings", path: "/settings" },
+  ];
+  return (
+    <div className="flex min-h-screen flex-col">
+      <header className="sticky top-0 z-10 border-b bg-background">
+        <nav className="mx-auto flex max-w-6xl gap-4 p-4">
+          {navItems.map((item) => (
+            <Button
+              key={item.path}
+              variant={location.pathname === item.path ? "secondary" : "ghost"}
+              asChild
+            >
+              <Link to={item.path}>{item.label}</Link>
+            </Button>
+          ))}
+        </nav>
+      </header>
+      <main className="flex-1 overflow-y-auto p-4">{children}</main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `AdminLayout` with Shadcn Button primitives
- keep header fixed and wrap routes with the new layout

## Testing
- `npm run lint` *(fails: `__dirname` is not defined)*
- `npm run build`
- `vendor/bin/phpunit tests` *(no tests executed)*

------
https://chatgpt.com/codex/tasks/task_e_688d334aa6b0833385844fd2bbfd95b5