### PR TITLE
Add admin navigation highlighting

### DIFF
--- a/clients/src/App.jsx
+++ b/clients/src/App.jsx
@@ -6,7 +6,6 @@ import {
   useLocation,
 } from "react-router-dom";
 import { useEffect } from "react";
-import highlightSubmenu from "@/lib/highlightSubmenu";
 import AdminLayout from "@/components/layout/AdminLayout.jsx";
 import AllAuctions from "./pages/AllAuctions.jsx";
 import Bids from "./pages/Bids.jsx";
@@ -28,7 +27,6 @@ function AppRoutes() {
   useEffect(() => {
     const newUrl = `admin.php?page=wpam-auctions&path=${location.pathname}`;
     window.history.replaceState({}, "", newUrl);
-    highlightSubmenu(location.pathname);
   }, [location]);
 
   return (

--- a/clients/src/components/layout/AdminLayout.jsx
+++ b/clients/src/components/layout/AdminLayout.jsx
@@ -1,5 +1,7 @@
 import { Link, useLocation } from "react-router-dom";
+import { useEffect } from "react";
 import { Button } from "@/components/ui/button";
+import highlightSubmenu from "@/lib/highlightSubmenu";
 
 export default function AdminLayout({ children }) {
   const location = useLocation();
@@ -7,6 +9,10 @@ export default function AdminLayout({ children }) {
     { label: "All Auctions", path: "/all-auctions" },
     { label: "Settings", path: "/settings" },
   ];
+
+  useEffect(() => {
+    highlightSubmenu(location.pathname);
+  }, [location.pathname]);
   return (
     <div className="flex min-h-screen flex-col">
       <header className="sticky top-0 z-10 border-b bg-background">


### PR DESCRIPTION
## Summary
- make AdminLayout highlight WP submenu via highlightSubmenu on route change
- keep query-string sync for current route

## Testing
- `composer install`
- `vendor/bin/phpunit` *(no tests configured)*
- `vendor/bin/phpcs admin includes public` *(fails: PHPCBF can fix violations)*
- `npm --prefix clients run lint` *(fails: 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688d471b937c8333853cc7a49f87a5ce