### PR TITLE
Use time() when scheduling cron events

### DIFF
--- a/includes/class-wpam-auction.php
+++ b/includes/class-wpam-auction.php
@@ -589,16 +589,16 @@ class WPAM_Auction {
        }
 
         public function schedule_cron() {
-                if ( ! wp_next_scheduled( 'wpam_check_ended_auctions' ) ) {
-                        wp_schedule_event( current_datetime()->getTimestamp(), 'hourly', 'wpam_check_ended_auctions' );
-                }
-                if ( ! wp_next_scheduled( 'wpam_update_auction_states' ) ) {
-                        wp_schedule_event( current_datetime()->getTimestamp(), 'hourly', 'wpam_update_auction_states' );
-                }
-                if ( ! wp_next_scheduled( 'wpam_send_auction_reminders' ) ) {
-                        wp_schedule_event( current_datetime()->getTimestamp(), 'wpam_quarter_hour', 'wpam_send_auction_reminders' );
-                }
-        }
+               if ( ! wp_next_scheduled( 'wpam_check_ended_auctions' ) ) {
+                       wp_schedule_event( time(), 'hourly', 'wpam_check_ended_auctions' );
+               }
+               if ( ! wp_next_scheduled( 'wpam_update_auction_states' ) ) {
+                       wp_schedule_event( time(), 'hourly', 'wpam_update_auction_states' );
+               }
+               if ( ! wp_next_scheduled( 'wpam_send_auction_reminders' ) ) {
+                       wp_schedule_event( time(), 'wpam_quarter_hour', 'wpam_send_auction_reminders' );
+               }
+       }
 
 	public function check_ended_auctions() {
 		$args = array(


### PR DESCRIPTION
## Summary
- use `time()` when scheduling cron events

## Testing
- `./vendor/bin/phpunit --test-suffix='.php' tests` *(fails: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_688de4c5939c833398b8837e0f4898d5