### PR TITLE
Require login for Pusher auth

### DIFF
--- a/public/class-wpam-public.php
+++ b/public/class-wpam-public.php
@@ -199,8 +199,12 @@ class WPAM_Public {
                 }
 
                 $channel   = sanitize_text_field( wp_unslash( $_POST['channel_name'] ) );
-                $socket_id  = sanitize_text_field( wp_unslash( $_POST['socket_id'] ) );
-                $user_id    = get_current_user_id();
+                $socket_id = sanitize_text_field( wp_unslash( $_POST['socket_id'] ) );
+                $user_id   = get_current_user_id();
+
+                if ( 0 === $user_id ) {
+                        wp_send_json_error( [ 'message' => __( 'Please login', 'wpam' ) ] );
+                }
 
                 if ( ! $this->realtime_provider || ! $this->realtime_provider->is_active() || ! function_exists( 'pusher_presence_auth' ) ) {
                         wp_send_json_error( [ 'message' => __( 'Pusher not configured', 'wpam' ) ] );

--- a/tests/test-pusher-auth.php
+++ b/tests/test-pusher-auth.php
@@ -1,0 +1,39 @@
+<?php
+use WPAM\Public\WPAM_Public;
+use WPAM\Includes\WPAM_Install;
+
+/**
+ * Tests for Pusher auth endpoint.
+ */
+class Test_WPAM_Pusher_Auth extends WP_Ajax_UnitTestCase {
+    /**
+     * Set up test case.
+     */
+    public function set_up(): void {
+        parent::set_up();
+        WPAM_Install::activate();
+        update_option( 'wpam_realtime_provider', 'none' );
+        new WPAM_Public();
+    }
+
+    /**
+     * Ensure pusher_auth rejects unauthenticated requests.
+     */
+    public function test_pusher_auth_requires_login() {
+        wp_set_current_user( 0 );
+        $_POST = array(
+            'nonce'        => wp_create_nonce( 'wpam_pusher_auth' ),
+            'channel_name' => 'presence-auction-1',
+            'socket_id'    => '123.456',
+        );
+        try {
+            $this->_handleAjax( 'wpam_pusher_auth' );
+        } catch ( WPAjaxDieContinueException $e ) {
+            $response = json_decode( $this->_last_response, true );
+            $this->assertFalse( $response['success'] );
+            $this->assertSame( 'Please login', $response['data']['message'] );
+            return;
+        }
+        $this->fail( 'Expected AJAX die.' );
+    }
+}


### PR DESCRIPTION
## Summary
- deny Pusher channel auth requests from users not logged in
- add AJAX test ensuring unauthenticated Pusher auth is rejected

## Testing
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Error establishing a database connection)*
- `vendor/bin/phpcs public/class-wpam-public.php tests/test-pusher-auth.php` *(fails: Tabs must be used to indent lines; spaces are not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_688df0ce79a08333bb9dfd10963445c9