### PR TITLE
Check user login before processing pusher leave

### DIFF
--- a/public/class-wpam-public.php
+++ b/public/class-wpam-public.php
@@ -227,6 +227,12 @@ class WPAM_Public {
         public function pusher_leave() {
                 check_ajax_referer( 'wpam_pusher_auth', 'nonce' );
 
+                $user_id = get_current_user_id();
+
+                if ( 0 === $user_id ) {
+                        wp_send_json_error( [ 'message' => __( 'Please login', 'wpam' ) ] );
+                }
+
                 if ( empty( $_POST['auction_id'] ) ) {
                         wp_send_json_error( [ 'message' => __( 'Invalid request', 'wpam' ) ] );
                 }


### PR DESCRIPTION
## Summary
- Ensure `pusher_leave` verifies the current user is logged in before handling a leave event

## Testing
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php --test-suffix .php tests` *(fails: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_688df28c59288333affb30d9ead36414