### PR TITLE
Sanitize KYC document in submission handler

### DIFF
--- a/includes/class-wpam-kyc.php
+++ b/includes/class-wpam-kyc.php
@@ -57,8 +57,9 @@ class WPAM_KYC {
 
     public function handle_kyc_submission( WP_REST_Request $request ) {
         $user_id = get_current_user_id();
+        $id_document = sanitize_text_field( $request['id_document'] );
         // In a real system, the document would be processed here.
-        do_action( 'wpam_kyc_submitted', $user_id, $request['id_document'] );
+        do_action( 'wpam_kyc_submitted', $user_id, $id_document );
         return rest_ensure_response( [ 'message' => __( 'Document received', 'wpam' ) ] );
     }
 }


### PR DESCRIPTION
## Summary
- Sanitize `id_document` request data before triggering `wpam_kyc_submitted`

## Testing
- `vendor/bin/phpcs includes/class-wpam-kyc.php` *(fails: numerous pre-existing coding standard errors)*
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_688df3bcf84883338c6f64f111a6a2f4