### PR TITLE
Escape message and display name in messages response

### DIFF
--- a/includes/class-wpam-messages.php
+++ b/includes/class-wpam-messages.php
@@ -55,8 +55,8 @@ class WPAM_Messages {
             $user = get_user_by( 'id', $row['user_id'] );
             $messages[] = [
                 'id'        => $row['id'],
-                'user'      => $user ? $user->display_name : __( 'Unknown', 'wpam' ),
-                'message'   => $row['message'],
+                'user'      => $user ? esc_html( $user->display_name ) : __( 'Unknown', 'wpam' ),
+                'message'   => esc_html( $row['message'] ),
                 'parent_id' => $row['parent_id'],
                 'date'      => $row['created_at'],
             ];


### PR DESCRIPTION
## Summary
- Escape user display name when fetching messages
- Escape message content before returning AJAX response

## Testing
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Error establishing a database connection)*
- `vendor/bin/phpcs --standard=phpcs.xml includes/class-wpam-messages.php` *(fails: 71 errors, 5 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688df3cde6c483338b26397003f6e1f2