### PR TITLE
Sanitize server info before audit log insertion

### DIFF
--- a/includes/class-wpam-bid.php
+++ b/includes/class-wpam-bid.php
@@ -49,8 +49,8 @@ class WPAM_Bid {
             [
                 'bid_id'     => $bid_id,
                 'user_id'    => $user_id,
-                'ip'         => isset( $_SERVER['REMOTE_ADDR'] ) ? $_SERVER['REMOTE_ADDR'] : '',
-                'user_agent' => isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '',
+                'ip'         => isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '',
+                'user_agent' => isset( $_SERVER['HTTP_USER_AGENT'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : '',
                 'logged_at'  => wp_date( 'Y-m-d H:i:s', null, wp_timezone() ),
             ],
             [ '%d', '%d', '%s', '%s', '%s' ]


### PR DESCRIPTION
## Summary
- Sanitize `$_SERVER['REMOTE_ADDR']` and `$_SERVER['HTTP_USER_AGENT']` before inserting into the audit log

## Testing
- `vendor/bin/phpcs --standard=WordPress --report=summary includes/class-wpam-bid.php`
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_688df3d3b3648333b79a0d4a7e4c5b06