### PR TITLE
Avoid clearing POST in REST bid handler

### DIFF
--- a/includes/class-wpam-bid.php
+++ b/includes/class-wpam-bid.php
@@ -410,7 +410,6 @@ class WPAM_Bid {
      * REST endpoint to place a bid.
      */
     public static function rest_place_bid( \WP_REST_Request $request ) {
-        $_POST = [];
         $auction_id = absint( $request['auction_id'] );
         $bid        = floatval( $request['bid'] );
         $max_bid    = $request->get_param( 'max_bid' );


### PR DESCRIPTION
## Summary
- stop resetting `$_POST` in REST bid endpoint and rely on local variables

## Testing
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Error establishing a database connection)*
- `vendor/bin/phpcs includes/class-wpam-bid.php`


------
https://chatgpt.com/codex/tasks/task_e_688df5e8c1b08333ab31c9cae443eada