### PR TITLE
Instantiate providers conditionally

### DIFF
--- a/includes/class-wpam-loader.php
+++ b/includes/class-wpam-loader.php
@@ -11,9 +11,11 @@ class WPAM_Loader {
         // Init classes
         // Register event listeners
         WPAM_Event_Bus::register( new WPAM_Notifications() );
-        $pusher_provider = new WPAM_Pusher_Provider();
-        if ( $pusher_provider->is_active() ) {
-            WPAM_Event_Bus::register( $pusher_provider );
+        if ( 'pusher' === get_option( 'wpam_realtime_provider', 'none' ) ) {
+                $pusher_provider = new WPAM_Pusher_Provider();
+                if ( $pusher_provider->is_active() ) {
+                        WPAM_Event_Bus::register( $pusher_provider );
+                }
         }
 
         new WPAM_Auction();

--- a/includes/class-wpam-notifications.php
+++ b/includes/class-wpam-notifications.php
@@ -16,25 +16,24 @@ class WPAM_Notifications {
         $phone   = get_user_meta( $user_id, 'billing_phone', true );
         $token   = get_user_meta( $user_id, 'wpam_firebase_token', true );
 
-        $sms_provider     = new WPAM_Twilio_Provider();
-        $push_provider    = new WPAM_Firebase_Provider();
-        $sendgrid_provider = new WPAM_SendGrid_Provider();
-
         $sent = false;
         if ( $push_enabled && $token ) {
-            $result = $push_provider->send( $token, $message );
-            $sent   = ! is_wp_error( $result );
+            $push_provider = new WPAM_Firebase_Provider();
+            $result        = $push_provider->send( $token, $message );
+            $sent          = ! is_wp_error( $result );
         }
 
         if ( ! $sent && $sms_enabled && $phone ) {
-            $result = $sms_provider->send( $phone, $message );
-            $sent   = ! is_wp_error( $result );
+            $sms_provider = new WPAM_Twilio_Provider();
+            $result       = $sms_provider->send( $phone, $message );
+            $sent         = ! is_wp_error( $result );
         }
 
         if ( ! $sent && $email_enabled ) {
             if ( $sendgrid_key ) {
-                $result = $sendgrid_provider->send( $user->user_email, $message );
-                $sent   = ! is_wp_error( $result );
+                $sendgrid_provider = new WPAM_SendGrid_Provider();
+                $result            = $sendgrid_provider->send( $user->user_email, $message );
+                $sent              = ! is_wp_error( $result );
             }
 
             if ( ! $sent ) {


### PR DESCRIPTION
## Summary
- Only register Pusher provider when realtime provider option is set to pusher
- Instantiate Firebase, Twilio, and SendGrid providers only after verifying their enable flags

## Testing
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Error establishing a database connection)*
- `vendor/bin/phpcs includes/class-wpam-notifications.php includes/class-wpam-loader.php` *(fails: Tabs must be used to indent lines; spaces are not allowed and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_688df5fc3a9883339280217a89ec7908