### PR TITLE
Handle webhook HTTP errors

### DIFF
--- a/includes/class-wpam-webhooks.php
+++ b/includes/class-wpam-webhooks.php
@@ -1,37 +1,54 @@
 <?php
+/**
+ * Webhook handlers.
+ *
+ * @package WP_Auction_Manager
+ */
+
 namespace WPAM\Includes;
 
 /**
  * Send webhook calls on key auction events.
  */
 class WPAM_Webhooks {
-    public function __construct() {
-        add_action( 'wpam_auction_end', [ $this, 'send_auction_end' ], 20, 1 );
-    }
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'wpam_auction_end', array( $this, 'send_auction_end' ), 20, 1 );
+	}
 
-    /**
-     * Triggered when an auction ends.
-     *
-     * @param int $auction_id Auction post ID.
-     */
-    public function send_auction_end( $auction_id ) {
-        $url = trim( get_option( 'wpam_webhook_url', '' ) );
-        if ( empty( $url ) ) {
-            return;
-        }
+	/**
+	 * Triggered when an auction ends.
+	 *
+	 * @param int $auction_id Auction post ID.
+	 */
+	public function send_auction_end( $auction_id ) {
+		$url = trim( get_option( 'wpam_webhook_url', '' ) );
+		if ( empty( $url ) ) {
+			return;
+		}
 
-        $payload = [
-            'event'      => 'auction_end',
-            'auction_id' => $auction_id,
-        ];
+		$payload = array(
+			'event'      => 'auction_end',
+			'auction_id' => $auction_id,
+		);
 
-        wp_remote_post(
-            $url,
-            [
-                'body'    => wp_json_encode( $payload ),
-                'headers' => [ 'Content-Type' => 'application/json' ],
-                'timeout' => 5,
-            ]
-        );
-    }
+		$args     = array(
+			'body'    => wp_json_encode( $payload ),
+			'headers' => array( 'Content-Type' => 'application/json' ),
+			'timeout' => 5,
+		);
+		$response = wp_remote_post( $url, $args );
+
+		if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) < 200 || wp_remote_retrieve_response_code( $response ) >= 300 ) {
+			error_log( 'WPAM webhook call failed: ' . ( is_wp_error( $response ) ? $response->get_error_message() : wp_remote_retrieve_body( $response ) ) );
+
+			// Retry once on failure.
+			$response = wp_remote_post( $url, $args );
+			if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) < 200 || wp_remote_retrieve_response_code( $response ) >= 300 ) {
+				error_log( 'WPAM webhook retry failed: ' . ( is_wp_error( $response ) ? $response->get_error_message() : wp_remote_retrieve_body( $response ) ) );
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- capture webhook responses and retry on failure

## Testing
- `vendor/bin/phpcs includes/class-wpam-webhooks.php`
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_688df60b6a1483338859c77990da8544