### PR TITLE
Use WooCommerce decimal helpers

### DIFF
--- a/admin/class-wpam-admin.php
+++ b/admin/class-wpam-admin.php
@@ -36,7 +36,7 @@ class WPAM_Admin {
 	}
 
 	public function register_settings() {
-		register_setting( 'wpam_settings', 'wpam_default_increment', array( 'sanitize_callback' => 'floatval' ) );
+               register_setting( 'wpam_settings', 'wpam_default_increment', array( 'sanitize_callback' => array( $this, 'sanitize_decimal' ) ) );
 		register_setting( 'wpam_settings', 'wpam_soft_close', array( 'sanitize_callback' => 'absint' ) );
 		register_setting( 'wpam_settings', 'wpam_enable_twilio', array( 'sanitize_callback' => 'rest_sanitize_boolean' ) );
 		register_setting( 'wpam_settings', 'wpam_lead_sms_alerts', array( 'sanitize_callback' => 'rest_sanitize_boolean' ) );
@@ -59,8 +59,8 @@ class WPAM_Admin {
 		register_setting( 'wpam_settings', 'wpam_default_auction_type', array( 'sanitize_callback' => 'sanitize_key' ) );
 		register_setting( 'wpam_settings', 'wpam_enable_proxy_bidding', array( 'sanitize_callback' => 'rest_sanitize_boolean' ) );
 		register_setting( 'wpam_settings', 'wpam_enable_silent_bidding', array( 'sanitize_callback' => 'rest_sanitize_boolean' ) );
-		register_setting( 'wpam_settings', 'wpam_buyer_premium', array( 'sanitize_callback' => 'floatval' ) );
-		register_setting( 'wpam_settings', 'wpam_seller_fee', array( 'sanitize_callback' => 'floatval' ) );
+               register_setting( 'wpam_settings', 'wpam_buyer_premium', array( 'sanitize_callback' => array( $this, 'sanitize_decimal' ) ) );
+               register_setting( 'wpam_settings', 'wpam_seller_fee', array( 'sanitize_callback' => array( $this, 'sanitize_decimal' ) ) );
 		register_setting( 'wpam_settings', 'wpam_webhook_url', array( 'sanitize_callback' => 'esc_url_raw' ) );
 
 		add_settings_section( 'wpam_general', __( 'Auction Defaults', 'wpam' ), '__return_false', 'wpam_settings' );
@@ -112,13 +112,17 @@ class WPAM_Admin {
 
 		add_settings_field( 'wpam_pusher_cluster', __( 'Pusher Cluster', 'wpam' ), array( $this, 'field_pusher_cluster' ), 'wpam_settings', 'wpam_realtime' );
 
-		add_settings_field( 'wpam_webhook_url', __( 'Webhook URL', 'wpam' ), array( $this, 'field_webhook_url' ), 'wpam_settings', 'wpam_webhooks' );
-	}
+               add_settings_field( 'wpam_webhook_url', __( 'Webhook URL', 'wpam' ), array( $this, 'field_webhook_url' ), 'wpam_settings', 'wpam_webhooks' );
+       }
 
-	public function field_twilio_sid() {
-		$value = esc_attr( get_option( 'wpam_twilio_sid', '' ) );
-		echo '<input type="text" class="regular-text" name="wpam_twilio_sid" value="' . $value . '" />';
-	}
+       public function sanitize_decimal( $value ) {
+               return function_exists( 'wc_format_decimal' ) ? wc_format_decimal( $value ) : (float) $value;
+       }
+
+       public function field_twilio_sid() {
+               $value = esc_attr( get_option( 'wpam_twilio_sid', '' ) );
+               echo '<input type="text" class="regular-text" name="wpam_twilio_sid" value="' . $value . '" />';
+       }
 
 	public function field_twilio_token() {
 		$value = esc_attr( get_option( 'wpam_twilio_token', '' ) );
@@ -557,10 +561,10 @@ class WPAM_Admin {
 
         private function get_setting_definitions() {
                 return array(
-                        'wpam_default_increment'   => array(
-                                'sanitize' => 'floatval',
-                                'schema'   => array( 'type' => 'number' ),
-                        ),
+                       'wpam_default_increment'   => array(
+                               'sanitize' => array( $this, 'sanitize_decimal' ),
+                               'schema'   => array( 'type' => 'number' ),
+                       ),
                         'wpam_soft_close'          => array(
                                 'sanitize' => 'absint',
                                 'schema'   => array( 'type' => 'integer' ),
@@ -649,14 +653,14 @@ class WPAM_Admin {
                                 'sanitize' => 'rest_sanitize_boolean',
                                 'schema'   => array( 'type' => 'boolean' ),
                         ),
-                        'wpam_buyer_premium'       => array(
-                                'sanitize' => 'floatval',
-                                'schema'   => array( 'type' => 'number' ),
-                        ),
-                        'wpam_seller_fee'          => array(
-                                'sanitize' => 'floatval',
-                                'schema'   => array( 'type' => 'number' ),
-                        ),
+                       'wpam_buyer_premium'       => array(
+                               'sanitize' => array( $this, 'sanitize_decimal' ),
+                               'schema'   => array( 'type' => 'number' ),
+                       ),
+                       'wpam_seller_fee'          => array(
+                               'sanitize' => array( $this, 'sanitize_decimal' ),
+                               'schema'   => array( 'type' => 'number' ),
+                       ),
                         'wpam_webhook_url'         => array(
                                 'sanitize' => 'esc_url_raw',
                                 'schema'   => array(

--- a/includes/class-wpam-auction.php
+++ b/includes/class-wpam-auction.php
@@ -498,10 +498,10 @@ class WPAM_Auction {
                        return;
                }
 
-		$user_id = intval( $highest['user_id'] );
-		$amount  = floatval( $highest['bid_amount'] );
+               $user_id = intval( $highest['user_id'] );
+               $amount  = function_exists( 'wc_format_decimal' ) ? wc_format_decimal( $highest['bid_amount'] ) : (float) $highest['bid_amount'];
 
-		$reserve = floatval( get_post_meta( $auction_id, '_auction_reserve', 0 ) );
+               $reserve = function_exists( 'wc_format_decimal' ) ? wc_format_decimal( get_post_meta( $auction_id, '_auction_reserve', 0 ) ) : (float) get_post_meta( $auction_id, '_auction_reserve', 0 );
 		if ( $reserve && $amount < $reserve ) {
 			$ending_reason = 'reserve_not_met';
 			if ( get_post_meta( $auction_id, '_auction_auto_relist', true ) ) {
@@ -541,7 +541,7 @@ class WPAM_Auction {
 			)
 		);
 
-		$fee = floatval( get_post_meta( $auction_id, '_auction_fee', 0 ) );
+               $fee = function_exists( 'wc_format_decimal' ) ? wc_format_decimal( get_post_meta( $auction_id, '_auction_fee', 0 ) ) : (float) get_post_meta( $auction_id, '_auction_fee', 0 );
 		$fee = apply_filters( 'wpam_auction_fee_calculated', $fee, $auction_id, $amount );
 		if ( $fee > 0 ) {
 			$item = new \WC_Order_Item_Fee();

--- a/includes/class-wpam-bid.php
+++ b/includes/class-wpam-bid.php
@@ -97,7 +97,7 @@ class WPAM_Bid {
             if ( isset( $seen[ $uid ] ) ) {
                 continue;
             }
-            $bid = floatval( $row->bid_amount );
+            $bid = function_exists( 'wc_format_decimal' ) ? (float) wc_format_decimal( $row->bid_amount ) : (float) $row->bid_amount;
             if ( $uid === $lead_user ) {
                 $statuses[ $uid ] = 'max';
             } elseif ( $bid === $highest ) {
@@ -119,7 +119,7 @@ class WPAM_Bid {
         }
 
         $auction_id = absint( $_POST['auction_id'] );
-        $bid        = floatval( $_POST['bid'] );
+        $bid        = function_exists( 'wc_format_decimal' ) ? (float) wc_format_decimal( $_POST['bid'] ) : (float) $_POST['bid'];
         $user_id    = get_current_user_id();
 
         if ( 0 === $user_id ) {
@@ -150,7 +150,7 @@ class WPAM_Bid {
 
         $order        = $reverse ? 'ASC' : 'DESC';
         $highest_row  = $wpdb->get_row( $wpdb->prepare( "SELECT user_id, bid_amount FROM $table WHERE auction_id = %d ORDER BY bid_amount {$order}, id DESC LIMIT 1", $auction_id ), ARRAY_A );
-        $highest      = $highest_row ? floatval( $highest_row['bid_amount'] ) : 0;
+        $highest      = $highest_row ? ( function_exists( 'wc_format_decimal' ) ? (float) wc_format_decimal( $highest_row['bid_amount'] ) : (float) $highest_row['bid_amount'] ) : 0;
         $highest_user = $highest_row ? intval( $highest_row['user_id'] ) : 0;
 
         $prev_highest_user = $highest_user;
@@ -159,14 +159,14 @@ class WPAM_Bid {
         $prev_lead_max  = 0;
         if ( $prev_lead_user ) {
             $prev_lead_max = get_user_meta( $prev_lead_user, 'wpam_proxy_max_' . $auction_id, true );
-            $prev_lead_max = $prev_lead_max ? floatval( $prev_lead_max ) : $highest;
+            $prev_lead_max = $prev_lead_max ? ( function_exists( 'wc_format_decimal' ) ? (float) wc_format_decimal( $prev_lead_max ) : (float) $prev_lead_max ) : $highest;
         } else {
             $prev_lead_max = $highest;
         }
 
         $proxy_enabled  = $reverse ? false : self::proxy_enabled( $auction_id );
         $silent_enabled = $sealed ? true : self::silent_enabled( $auction_id );
-        $max_bid        = isset( $_POST['max_bid'] ) ? floatval( $_POST['max_bid'] ) : $bid;
+        $max_bid        = isset( $_POST['max_bid'] ) ? ( function_exists( 'wc_format_decimal' ) ? (float) wc_format_decimal( $_POST['max_bid'] ) : (float) $_POST['max_bid'] ) : $bid;
         if ( $max_bid < $bid ) {
             $max_bid = $bid;
         }
@@ -241,7 +241,7 @@ class WPAM_Bid {
 
             if ( $highest_user && $highest_user !== $user_id ) {
                 $prev_max = get_user_meta( $highest_user, 'wpam_proxy_max_' . $auction_id, true );
-                $prev_max = $prev_max ? floatval( $prev_max ) : $highest;
+                $prev_max = $prev_max ? ( function_exists( 'wc_format_decimal' ) ? (float) wc_format_decimal( $prev_max ) : (float) $prev_max ) : $highest;
                 if ( $prev_max > $place_bid ) {
                     $auto_bid = min( $prev_max, $place_bid + $increment );
                     $wpdb->insert(
@@ -299,7 +299,7 @@ class WPAM_Bid {
         // Determine new highest bid after processing
         $new_highest_row  = $wpdb->get_row( $wpdb->prepare( "SELECT user_id, bid_amount FROM $table WHERE auction_id = %d ORDER BY bid_amount {$order}, id DESC LIMIT 1", $auction_id ), ARRAY_A );
         $new_highest_user = $new_highest_row ? intval( $new_highest_row['user_id'] ) : 0;
-        $new_highest      = $new_highest_row ? floatval( $new_highest_row['bid_amount'] ) : 0;
+        $new_highest      = $new_highest_row ? ( function_exists( 'wc_format_decimal' ) ? (float) wc_format_decimal( $new_highest_row['bid_amount'] ) : (float) $new_highest_row['bid_amount'] ) : 0;
         if ( $new_lead_user !== $prev_lead_user ) {
             update_post_meta( $auction_id, '_auction_lead_user', $new_lead_user );
         }
@@ -379,7 +379,7 @@ class WPAM_Bid {
 
         $query   = $reverse ? "SELECT MIN(bid_amount) FROM $table WHERE auction_id = %d" : "SELECT MAX(bid_amount) FROM $table WHERE auction_id = %d";
         $highest = $wpdb->get_var( $wpdb->prepare( $query, $auction_id ) );
-        $highest = $highest ? floatval( $highest ) : 0;
+        $highest = $highest ? ( function_exists( 'wc_format_decimal' ) ? (float) wc_format_decimal( $highest ) : (float) $highest ) : 0;
         $lead_user = intval( get_post_meta( $auction_id, '_auction_lead_user', true ) );
 
         $lead_user = intval( get_post_meta( $auction_id, '_auction_lead_user', true ) );
@@ -411,10 +411,10 @@ class WPAM_Bid {
      */
     public static function rest_place_bid( \WP_REST_Request $request ) {
         $auction_id = absint( $request['auction_id'] );
-        $bid        = floatval( $request['bid'] );
+        $bid        = function_exists( 'wc_format_decimal' ) ? (float) wc_format_decimal( $request['bid'] ) : (float) $request['bid'];
         $max_bid    = $request->get_param( 'max_bid' );
         if ( null !== $max_bid ) {
-            $max_bid = floatval( $max_bid );
+            $max_bid = function_exists( 'wc_format_decimal' ) ? (float) wc_format_decimal( $max_bid ) : (float) $max_bid;
         }
 
         // Reuse internal logic from place_bid without nonce check.
@@ -440,7 +440,7 @@ class WPAM_Bid {
 
         $order        = $reverse ? 'ASC' : 'DESC';
         $highest_row  = $wpdb->get_row( $wpdb->prepare( "SELECT user_id, bid_amount FROM $table WHERE auction_id = %d ORDER BY bid_amount {$order}, id DESC LIMIT 1", $auction_id ), ARRAY_A );
-        $highest      = $highest_row ? floatval( $highest_row['bid_amount'] ) : 0;
+        $highest      = $highest_row ? ( function_exists( 'wc_format_decimal' ) ? (float) wc_format_decimal( $highest_row['bid_amount'] ) : (float) $highest_row['bid_amount'] ) : 0;
         $highest_user = $highest_row ? intval( $highest_row['user_id'] ) : 0;
 
         $prev_highest_user = $highest_user;
@@ -449,7 +449,7 @@ class WPAM_Bid {
         $prev_lead_max  = 0;
         if ( $prev_lead_user ) {
             $prev_lead_max = get_user_meta( $prev_lead_user, 'wpam_proxy_max_' . $auction_id, true );
-            $prev_lead_max = $prev_lead_max ? floatval( $prev_lead_max ) : $highest;
+            $prev_lead_max = $prev_lead_max ? ( function_exists( 'wc_format_decimal' ) ? (float) wc_format_decimal( $prev_lead_max ) : (float) $prev_lead_max ) : $highest;
         } else {
             $prev_lead_max = $highest;
         }
@@ -521,7 +521,7 @@ class WPAM_Bid {
 
             if ( $highest_user && $highest_user !== $user_id ) {
                 $prev_max = get_user_meta( $highest_user, 'wpam_proxy_max_' . $auction_id, true );
-                $prev_max = $prev_max ? floatval( $prev_max ) : $highest;
+                $prev_max = $prev_max ? ( function_exists( 'wc_format_decimal' ) ? (float) wc_format_decimal( $prev_max ) : (float) $prev_max ) : $highest;
                 if ( $prev_max > $place_bid ) {
                     $auto_bid = min( $prev_max, $place_bid + $increment );
                     $wpdb->insert(
@@ -576,7 +576,7 @@ class WPAM_Bid {
 
         $new_highest_row  = $wpdb->get_row( $wpdb->prepare( "SELECT user_id, bid_amount FROM $table WHERE auction_id = %d ORDER BY bid_amount {$order}, id DESC LIMIT 1", $auction_id ), ARRAY_A );
         $new_highest_user = $new_highest_row ? intval( $new_highest_row['user_id'] ) : 0;
-        $new_highest      = $new_highest_row ? floatval( $new_highest_row['bid_amount'] ) : 0;
+        $new_highest      = $new_highest_row ? ( function_exists( 'wc_format_decimal' ) ? (float) wc_format_decimal( $new_highest_row['bid_amount'] ) : (float) $new_highest_row['bid_amount'] ) : 0;
         if ( $new_lead_user !== $prev_lead_user ) {
             update_post_meta( $auction_id, '_auction_lead_user', $new_lead_user );
         }
@@ -641,7 +641,7 @@ class WPAM_Bid {
 
         $query   = $reverse ? "SELECT MIN(bid_amount) FROM $table WHERE auction_id = %d" : "SELECT MAX(bid_amount) FROM $table WHERE auction_id = %d";
         $highest = $wpdb->get_var( $wpdb->prepare( $query, $auction_id ) );
-        $highest = $highest ? floatval( $highest ) : 0;
+        $highest = $highest ? ( function_exists( 'wc_format_decimal' ) ? (float) wc_format_decimal( $highest ) : (float) $highest ) : 0;
 
         if ( $sealed || self::silent_enabled( $auction_id ) ) {
             $end   = get_post_meta( $auction_id, '_auction_end', true );
@@ -706,7 +706,7 @@ class WPAM_Bid {
                 'id'     => intval( $row['auction_id'] ),
                 'title'  => get_the_title( $row['auction_id'] ),
                 'url'    => get_permalink( $row['auction_id'] ),
-                'amount' => floatval( $row['bid_amount'] ),
+                'amount' => function_exists( 'wc_format_decimal' ) ? (float) wc_format_decimal( $row['bid_amount'] ) : (float) $row['bid_amount'],
                 'time'   => mysql2date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $row['bid_time'] ),
             ];
         }

--- a/includes/class-wpam-html.php
+++ b/includes/class-wpam-html.php
@@ -39,7 +39,7 @@ class WPAM_HTML {
       ? $wpdb->prepare( "SELECT MIN(bid_amount) FROM {$wpdb->prefix}wc_auction_bids WHERE auction_id = %d", $auction_id )
       : $wpdb->prepare( "SELECT MAX(bid_amount) FROM {$wpdb->prefix}wc_auction_bids WHERE auction_id = %d", $auction_id );
     $highest = $wpdb->get_var( $query );
-    $highest = $highest ? floatval( $highest ) : 0;
+    $highest = $highest ? ( function_exists( 'wc_format_decimal' ) ? wc_format_decimal( $highest ) : $highest ) : 0;
 
     $silent          = ( 'sealed' === $type ) || ( get_option( 'wpam_enable_silent_bidding' ) && get_post_meta( $auction_id, '_auction_silent_bidding', true ) );
     $display_highest = ( $silent && $now < $end_ts ) ? __( 'Hidden', 'wpam' ) : wc_price( $highest );

--- a/tests/test-auction-types.php
+++ b/tests/test-auction-types.php
@@ -53,7 +53,7 @@ class Test_WPAM_Auction_Types extends WP_Ajax_UnitTestCase {
         try { $this->_handleAjax( 'wpam_get_highest_bid' ); } catch ( WPAjaxDieContinueException $e ) {
             $resp = json_decode( $this->_last_response, true );
         }
-        $this->assertSame( 90.0, floatval( $resp['data']['highest_bid'] ) );
+        $this->assertSame( 90.0, function_exists( 'wc_format_decimal' ) ? (float) wc_format_decimal( $resp['data']['highest_bid'] ) : (float) $resp['data']['highest_bid'] );
     }
 
     public function test_sealed_bid_hidden_until_end() {
@@ -78,7 +78,7 @@ class Test_WPAM_Auction_Types extends WP_Ajax_UnitTestCase {
         try { $this->_handleAjax( 'wpam_get_highest_bid' ); } catch ( WPAjaxDieContinueException $e ) {
             $resp = json_decode( $this->_last_response, true );
         }
-        $this->assertSame( 0.0, floatval( $resp['data']['highest_bid'] ) );
+        $this->assertSame( 0.0, function_exists( 'wc_format_decimal' ) ? (float) wc_format_decimal( $resp['data']['highest_bid'] ) : (float) $resp['data']['highest_bid'] );
 
         update_post_meta( $auction_id, '_auction_end', date( 'Y-m-d H:i:s', time() - 10 ) );
 
@@ -89,7 +89,7 @@ class Test_WPAM_Auction_Types extends WP_Ajax_UnitTestCase {
         try { $this->_handleAjax( 'wpam_get_highest_bid' ); } catch ( WPAjaxDieContinueException $e ) {
             $resp = json_decode( $this->_last_response, true );
         }
-        $this->assertSame( 50.0, floatval( $resp['data']['highest_bid'] ) );
+        $this->assertSame( 50.0, function_exists( 'wc_format_decimal' ) ? (float) wc_format_decimal( $resp['data']['highest_bid'] ) : (float) $resp['data']['highest_bid'] );
     }
 
     public function test_sealed_second_bid_denied() {


### PR DESCRIPTION
## Summary
- replace float casts in settings with a WooCommerce-aware `sanitize_decimal` method
- sanitize auction bids, reserve prices and fees using `wc_format_decimal`
- update HTML and tests to rely on WooCommerce helpers instead of `floatval`

## Testing
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Error establishing a database connection)*
- `php -l admin/class-wpam-admin.php includes/class-wpam-auction.php includes/class-wpam-bid.php includes/class-wpam-html.php tests/test-auction-types.php`


------
https://chatgpt.com/codex/tasks/task_e_688dfb5eb1c4833382d27aaee1f9ef23