### PR TITLE
fix: append submenu items once

### DIFF
--- a/clients/src/lib/highlightSubmenu.js
+++ b/clients/src/lib/highlightSubmenu.js
@@ -2,41 +2,46 @@ export default function highlightSubmenu(path) {
   const menuRoot = document.querySelector('#toplevel_page_wpam-auctions');
   if (!menuRoot) return;
 
-  if (!menuRoot.querySelector('.wp-submenu')) {
-    const ul = document.createElement('ul');
-    ul.className = 'wp-submenu wp-submenu-wrap';
+  const items = [
+    { label: 'All Auctions', path: '/all-auctions' },
+    { label: 'Bids', path: '/bids' },
+    { label: 'Messages', path: '/messages' },
+    { label: 'Logs', path: '/logs' },
+    { label: 'Flagged Users', path: '/flagged-users' },
+    { label: 'Settings', path: '/settings' },
+  ];
 
-    const items = [
-      { label: 'All Auctions', path: '/all-auctions' },
-      { label: 'Bids', path: '/bids' },
-      { label: 'Messages', path: '/messages' },
-      { label: 'Logs', path: '/logs' },
-      { label: 'Flagged Users', path: '/flagged-users' },
-      { label: 'Settings', path: '/settings' },
-    ];
+  let submenu = menuRoot.querySelector('.wp-submenu');
+  if (!submenu) {
+    submenu = document.createElement('ul');
+    submenu.className = 'wp-submenu wp-submenu-wrap';
 
     const head = document.createElement('li');
     head.className = 'wp-submenu-head';
     head.innerText = 'Auctions';
-    ul.appendChild(head);
+    submenu.appendChild(head);
 
+    menuRoot.appendChild(submenu);
+  }
+
+  if (!submenu.querySelector(`a[href*="path=${items[0].path}"]`)) {
     items.forEach((item, index) => {
       const li = document.createElement('li');
-      if (index === 0) li.classList.add('wp-first-item');
+      if (index === 0 && !submenu.querySelector('li.wp-first-item')) {
+        li.classList.add('wp-first-item');
+      }
 
       const a = document.createElement('a');
       a.href = `admin.php?page=wpam-auctions&path=${item.path}`;
       a.textContent = item.label;
 
       li.appendChild(a);
-      ul.appendChild(li);
+      submenu.appendChild(li);
     });
-
-    menuRoot.appendChild(ul);
   }
 
-  menuRoot.querySelectorAll('li').forEach((li) => li.classList.remove('current'));
-  const active = menuRoot.querySelector(`a[href*="path=${path}"]`);
+  submenu.querySelectorAll('li').forEach((li) => li.classList.remove('current'));
+  const active = submenu.querySelector(`a[href*="path=${path}"]`);
   if (active && active.parentElement) {
     active.parentElement.classList.add('current');
     menuRoot.classList.add('wp-has-current-submenu', 'wp-menu-open');


### PR DESCRIPTION
## Summary
- avoid skipping submenu setup when WordPress pre-populates it
- add custom submenu links only if they haven't been added yet

## Testing
- `npm test` *(fails: Missing script "test")*
- `vendor/bin/phpunit tests` *(No tests executed)*
- `node test-submenu.mjs`

------
https://chatgpt.com/codex/tasks/task_e_688dfce34df88333bd49f2ab5e8fa816