### PR TITLE
Add data tables for admin pages

### DIFF
--- a/clients/postcss.config.js
+++ b/clients/postcss.config.js
@@ -1,9 +1,3 @@
-import tailwindcss from '@tailwindcss/postcss';
-import autoprefixer from 'autoprefixer';
-
-// export default {
-//   plugins: [tailwindcss, autoprefixer]
-// }
 export default {
   plugins: {
     '@tailwindcss/postcss': {},

--- a/clients/src/pages/Bids.jsx
+++ b/clients/src/pages/Bids.jsx
@@ -1,12 +1,104 @@
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
 export default function Bids() {
+  const [bids, setBids] = useState([]);
+  const [auctionId, setAuctionId] = useState(
+    new URLSearchParams(window.location.search).get('auction_id') || ''
+  );
+  const [page, setPage] = useState(1);
+  const [pageCount, setPageCount] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const { bids_endpoint, nonce } = window.wpamData || {};
+    if (!bids_endpoint) return;
+    setLoading(true);
+    setError('');
+    axios
+      .get(bids_endpoint, {
+        headers: { 'X-WP-Nonce': nonce },
+        params: {
+          auction_id: auctionId || undefined,
+          page,
+          per_page: 10,
+        },
+      })
+      .then((res) => {
+        setBids(res.data.data || []);
+        setPageCount(Math.ceil(res.data.total / 10));
+      })
+      .catch(() => setError('Failed to load bids.'))
+      .finally(() => setLoading(false));
+  }, [auctionId, page]);
+
   return (
     <Card>
       <CardHeader>
         <CardTitle>Bids</CardTitle>
       </CardHeader>
       <CardContent>
-        <p>Manage bids here.</p>
+        <div className="mb-4 flex items-end gap-2">
+          <div className="w-40">
+            <Input
+              placeholder="Auction ID"
+              value={auctionId}
+              onChange={(e) => setAuctionId(e.target.value)}
+            />
+          </div>
+          <Button onClick={() => setPage(1)} variant="secondary">
+            Apply
+          </Button>
+        </div>
+        {loading ? (
+          <p>Loading...</p>
+        ) : error ? (
+          <p className="text-destructive">{error}</p>
+        ) : (
+          <>
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="border-b font-semibold text-left">
+                  <th className="px-2 py-1">User</th>
+                  <th className="px-2 py-1">Amount</th>
+                  <th className="px-2 py-1">Bid Time</th>
+                </tr>
+              </thead>
+              <tbody>
+                {bids.map((bid, idx) => (
+                  <tr key={idx} className="border-b last:border-b-0">
+                    <td className="px-2 py-1">{bid.user}</td>
+                    <td className="px-2 py-1">{bid.amount}</td>
+                    <td className="px-2 py-1">{bid.bid_time}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <div className="mt-4 flex items-center justify-between gap-2">
+              <Button
+                variant="outline"
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page === 1}
+              >
+                Previous
+              </Button>
+              <span>
+                Page {page} of {pageCount || 1}
+              </span>
+              <Button
+                variant="outline"
+                onClick={() => setPage((p) => p + 1)}
+                disabled={page >= pageCount}
+              >
+                Next
+              </Button>
+            </div>
+          </>
+        )}
       </CardContent>
     </Card>
   );

--- a/clients/src/pages/FlaggedUsers.jsx
+++ b/clients/src/pages/FlaggedUsers.jsx
@@ -1,12 +1,84 @@
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
 export default function FlaggedUsers() {
+  const [users, setUsers] = useState([]);
+  const [page, setPage] = useState(1);
+  const [pageCount, setPageCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const { flagged_endpoint, nonce } = window.wpamData || {};
+    if (!flagged_endpoint) return;
+    setLoading(true);
+    setError('');
+    axios
+      .get(flagged_endpoint, {
+        headers: { 'X-WP-Nonce': nonce },
+        params: { page, per_page: 10 },
+      })
+      .then((res) => {
+        setUsers(res.data.data || []);
+        setPageCount(Math.ceil(res.data.total / 10));
+      })
+      .catch(() => setError('Failed to load flagged users.'))
+      .finally(() => setLoading(false));
+  }, [page]);
+
   return (
     <Card>
       <CardHeader>
         <CardTitle>Flagged Users</CardTitle>
       </CardHeader>
       <CardContent>
-        <p>List of flagged users.</p>
+        {loading ? (
+          <p>Loading...</p>
+        ) : error ? (
+          <p className="text-destructive">{error}</p>
+        ) : (
+          <>
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="border-b font-semibold text-left">
+                  <th className="px-2 py-1">User</th>
+                  <th className="px-2 py-1">Reason</th>
+                  <th className="px-2 py-1">Flagged At</th>
+                </tr>
+              </thead>
+              <tbody>
+                {users.map((u, idx) => (
+                  <tr key={idx} className="border-b last:border-b-0">
+                    <td className="px-2 py-1">{u.user}</td>
+                    <td className="px-2 py-1">{u.reason}</td>
+                    <td className="px-2 py-1">{u.flagged_at}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <div className="mt-4 flex items-center justify-between gap-2">
+              <Button
+                variant="outline"
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page === 1}
+              >
+                Previous
+              </Button>
+              <span>
+                Page {page} of {pageCount || 1}
+              </span>
+              <Button
+                variant="outline"
+                onClick={() => setPage((p) => p + 1)}
+                disabled={page >= pageCount}
+              >
+                Next
+              </Button>
+            </div>
+          </>
+        )}
       </CardContent>
     </Card>
   );

--- a/clients/src/pages/Logs.jsx
+++ b/clients/src/pages/Logs.jsx
@@ -1,12 +1,88 @@
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
 export default function Logs() {
+  const [logs, setLogs] = useState([]);
+  const [page, setPage] = useState(1);
+  const [pageCount, setPageCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const { logs_endpoint, nonce } = window.wpamData || {};
+    if (!logs_endpoint) return;
+    setLoading(true);
+    setError('');
+    axios
+      .get(logs_endpoint, {
+        headers: { 'X-WP-Nonce': nonce },
+        params: { page, per_page: 10 },
+      })
+      .then((res) => {
+        setLogs(res.data.data || []);
+        setPageCount(Math.ceil(res.data.total / 10));
+      })
+      .catch(() => setError('Failed to load logs.'))
+      .finally(() => setLoading(false));
+  }, [page]);
+
   return (
     <Card>
       <CardHeader>
         <CardTitle>Logs</CardTitle>
       </CardHeader>
       <CardContent>
-        <p>System logs.</p>
+        {loading ? (
+          <p>Loading...</p>
+        ) : error ? (
+          <p className="text-destructive">{error}</p>
+        ) : (
+          <>
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="border-b font-semibold text-left">
+                  <th className="px-2 py-1">Auction</th>
+                  <th className="px-2 py-1">Admin</th>
+                  <th className="px-2 py-1">Action</th>
+                  <th className="px-2 py-1">Details</th>
+                  <th className="px-2 py-1">Date</th>
+                </tr>
+              </thead>
+              <tbody>
+                {logs.map((log, idx) => (
+                  <tr key={idx} className="border-b last:border-b-0">
+                    <td className="px-2 py-1">{log.auction}</td>
+                    <td className="px-2 py-1">{log.admin}</td>
+                    <td className="px-2 py-1">{log.action}</td>
+                    <td className="px-2 py-1">{log.details}</td>
+                    <td className="px-2 py-1">{log.date}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <div className="mt-4 flex items-center justify-between gap-2">
+              <Button
+                variant="outline"
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page === 1}
+              >
+                Previous
+              </Button>
+              <span>
+                Page {page} of {pageCount || 1}
+              </span>
+              <Button
+                variant="outline"
+                onClick={() => setPage((p) => p + 1)}
+                disabled={page >= pageCount}
+              >
+                Next
+              </Button>
+            </div>
+          </>
+        )}
       </CardContent>
     </Card>
   );

--- a/clients/src/pages/Messages.jsx
+++ b/clients/src/pages/Messages.jsx
@@ -1,12 +1,106 @@
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
 export default function Messages() {
+  const [messages, setMessages] = useState([]);
+  const [search, setSearch] = useState('');
+  const [page, setPage] = useState(1);
+  const [pageCount, setPageCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const { messages_endpoint, nonce } = window.wpamData || {};
+    if (!messages_endpoint) return;
+    setLoading(true);
+    setError('');
+    axios
+      .get(messages_endpoint, {
+        headers: { 'X-WP-Nonce': nonce },
+        params: {
+          search: search || undefined,
+          page,
+          per_page: 10,
+        },
+      })
+      .then((res) => {
+        setMessages(res.data.data || []);
+        setPageCount(Math.ceil(res.data.total / 10));
+      })
+      .catch(() => setError('Failed to load messages.'))
+      .finally(() => setLoading(false));
+  }, [search, page]);
+
   return (
     <Card>
       <CardHeader>
         <CardTitle>Messages</CardTitle>
       </CardHeader>
       <CardContent>
-        <p>User messages will appear here.</p>
+        <div className="mb-4 flex items-end gap-2">
+          <div className="w-40">
+            <Input
+              placeholder="Search"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+          </div>
+          <Button onClick={() => setPage(1)} variant="secondary">
+            Apply
+          </Button>
+        </div>
+        {loading ? (
+          <p>Loading...</p>
+        ) : error ? (
+          <p className="text-destructive">{error}</p>
+        ) : (
+          <>
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="border-b font-semibold text-left">
+                  <th className="px-2 py-1">Auction</th>
+                  <th className="px-2 py-1">User</th>
+                  <th className="px-2 py-1">Message</th>
+                  <th className="px-2 py-1">Status</th>
+                  <th className="px-2 py-1">Date</th>
+                </tr>
+              </thead>
+              <tbody>
+                {messages.map((msg, idx) => (
+                  <tr key={idx} className="border-b last:border-b-0">
+                    <td className="px-2 py-1">{msg.auction}</td>
+                    <td className="px-2 py-1">{msg.user}</td>
+                    <td className="px-2 py-1">{msg.message}</td>
+                    <td className="px-2 py-1">{msg.status}</td>
+                    <td className="px-2 py-1">{msg.date}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <div className="mt-4 flex items-center justify-between gap-2">
+              <Button
+                variant="outline"
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page === 1}
+              >
+                Previous
+              </Button>
+              <span>
+                Page {page} of {pageCount || 1}
+              </span>
+              <Button
+                variant="outline"
+                onClick={() => setPage((p) => p + 1)}
+                disabled={page >= pageCount}
+              >
+                Next
+              </Button>
+            </div>
+          </>
+        )}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary
- load auction bids, messages, logs and flagged users via REST endpoints
- display results in ShadCN-styled tables with pagination, loading and error states
- clean up PostCSS config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688dfcfaa7a88333add72b08006f585e