### PR TITLE
Refactor bidding logic with strategy pattern

### DIFF
--- a/includes/bidding/BidStrategyInterface.php
+++ b/includes/bidding/BidStrategyInterface.php
@@ -1,0 +1,6 @@
+<?php
+namespace WPAM\Includes\Bidding;
+
+interface BidStrategyInterface {
+    public function place_bid( int $auction_id, int $user_id, float $bid, float $max_bid );
+}

--- a/includes/bidding/ProxyStrategy.php
+++ b/includes/bidding/ProxyStrategy.php
@@ -1,0 +1,67 @@
+<?php
+namespace WPAM\Includes\Bidding;
+
+use WPAM\Includes\WPAM_Auction;
+use WPAM\Includes\WPAM_Bid;
+
+class ProxyStrategy implements BidStrategyInterface {
+    public function place_bid( int $auction_id, int $user_id, float $bid, float $max_bid ) {
+        global $wpdb;
+        $table = $wpdb->prefix . 'wc_auction_bids';
+
+        $order       = 'DESC';
+        $highest_row = $wpdb->get_row( $wpdb->prepare( "SELECT user_id, bid_amount FROM $table WHERE auction_id = %d ORDER BY bid_amount {$order}, id DESC LIMIT 1", $auction_id ), ARRAY_A );
+        $highest     = $highest_row ? ( function_exists( 'wc_format_decimal' ) ? (float) wc_format_decimal( $highest_row['bid_amount'] ) : (float) $highest_row['bid_amount'] ) : 0;
+        $highest_user = $highest_row ? intval( $highest_row['user_id'] ) : 0;
+
+        $increment = WPAM_Auction::get_bid_increment( $auction_id, $highest );
+
+        if ( $max_bid < $highest + $increment ) {
+            wp_send_json_error( [ 'message' => __( 'Bid too low', 'wpam' ) ] );
+        }
+
+        $place_bid = ( $highest > 0 ) ? min( $max_bid, $highest + $increment ) : $max_bid;
+        $wpdb->insert(
+            $table,
+            [
+                'auction_id' => $auction_id,
+                'user_id'    => $user_id,
+                'bid_amount' => $place_bid,
+                'bid_time'   => wp_date( 'Y-m-d H:i:s', null, wp_timezone() ),
+            ],
+            [ '%d', '%d', '%f', '%s' ]
+        );
+        WPAM_Bid::log_bid( $wpdb->insert_id, $user_id );
+        do_action( 'wpam_bid_placed', $auction_id, $user_id, $place_bid );
+        update_user_meta( $user_id, 'wpam_proxy_max_' . $auction_id, $max_bid );
+
+        $bid = $place_bid;
+
+        if ( $highest_user && $highest_user !== $user_id ) {
+            $prev_max = get_user_meta( $highest_user, 'wpam_proxy_max_' . $auction_id, true );
+            $prev_max = $prev_max ? ( function_exists( 'wc_format_decimal' ) ? (float) wc_format_decimal( $prev_max ) : (float) $prev_max ) : $highest;
+            if ( $prev_max > $place_bid ) {
+                $auto_bid = min( $prev_max, $place_bid + $increment );
+                $wpdb->insert(
+                    $table,
+                    [
+                        'auction_id' => $auction_id,
+                        'user_id'    => $highest_user,
+                        'bid_amount' => $auto_bid,
+                        'bid_time'   => wp_date( 'Y-m-d H:i:s', null, wp_timezone() ),
+                    ],
+                    [ '%d', '%d', '%f', '%s' ]
+                );
+                WPAM_Bid::log_bid( $wpdb->insert_id, $highest_user );
+                do_action( 'wpam_bid_placed', $auction_id, $highest_user, $auto_bid );
+                $bid = $auto_bid;
+            } else {
+                $highest_user = $user_id;
+            }
+        } else {
+            $highest_user = $user_id;
+        }
+
+        return [ 'bid' => $bid ];
+    }
+}

--- a/includes/bidding/SealedStrategy.php
+++ b/includes/bidding/SealedStrategy.php
@@ -1,0 +1,4 @@
+<?php
+namespace WPAM\Includes\Bidding;
+
+class SealedStrategy extends StandardStrategy implements BidStrategyInterface {}

--- a/includes/bidding/SilentStrategy.php
+++ b/includes/bidding/SilentStrategy.php
@@ -1,0 +1,4 @@
+<?php
+namespace WPAM\Includes\Bidding;
+
+class SilentStrategy extends StandardStrategy implements BidStrategyInterface {}

--- a/includes/bidding/StandardStrategy.php
+++ b/includes/bidding/StandardStrategy.php
@@ -1,0 +1,45 @@
+<?php
+namespace WPAM\Includes\Bidding;
+
+use WPAM\Includes\WPAM_Auction;
+use WPAM\Includes\WPAM_Bid;
+
+class StandardStrategy implements BidStrategyInterface {
+    public function place_bid( int $auction_id, int $user_id, float $bid, float $max_bid ) {
+        global $wpdb;
+        $table   = $wpdb->prefix . 'wc_auction_bids';
+        $reverse = 'reverse' === get_post_meta( $auction_id, '_auction_type', true );
+
+        $order       = $reverse ? 'ASC' : 'DESC';
+        $highest_row = $wpdb->get_row( $wpdb->prepare( "SELECT bid_amount FROM $table WHERE auction_id = %d ORDER BY bid_amount {$order}, id DESC LIMIT 1", $auction_id ) );
+        $highest     = $highest_row ? ( function_exists( 'wc_format_decimal' ) ? (float) wc_format_decimal( $highest_row->bid_amount ) : (float) $highest_row->bid_amount ) : 0;
+
+        $increment = WPAM_Auction::get_bid_increment( $auction_id, $highest );
+
+        if ( $reverse ) {
+            if ( $highest_row && $bid > $highest - $increment ) {
+                wp_send_json_error( [ 'message' => __( 'Bid too high', 'wpam' ) ] );
+            }
+        } else {
+            if ( $bid < $highest + $increment ) {
+                wp_send_json_error( [ 'message' => __( 'Bid too low', 'wpam' ) ] );
+            }
+        }
+
+        $wpdb->insert(
+            $table,
+            [
+                'auction_id' => $auction_id,
+                'user_id'    => $user_id,
+                'bid_amount' => $bid,
+                'bid_time'   => wp_date( 'Y-m-d H:i:s', null, wp_timezone() ),
+            ],
+            [ '%d', '%d', '%f', '%s' ]
+        );
+        $insert_id = $wpdb->insert_id;
+        WPAM_Bid::log_bid( $insert_id, $user_id );
+        do_action( 'wpam_bid_placed', $auction_id, $user_id, $bid );
+
+        return [ 'bid' => $bid ];
+    }
+}

--- a/tests/test-bid-strategies.php
+++ b/tests/test-bid-strategies.php
@@ -1,0 +1,149 @@
+<?php
+use WPAM\Includes\WPAM_Bid;
+
+class Test_WPAM_Bid_Strategies extends WP_Ajax_UnitTestCase {
+    public function set_up() : void {
+        parent::set_up();
+        update_option( 'wpam_enable_proxy_bidding', 0 );
+        update_option( 'wpam_enable_silent_bidding', 0 );
+        new WPAM_Bid();
+    }
+
+    public function test_standard_bid_too_low() {
+        $auction_id = $this->factory->post->create([
+            'post_type' => 'product',
+        ]);
+        update_post_meta( $auction_id, '_auction_start', date( 'Y-m-d H:i:s', time() - 3600 ) );
+        update_post_meta( $auction_id, '_auction_end', date( 'Y-m-d H:i:s', time() + 3600 ) );
+
+        $u1 = $this->factory->user->create();
+        $u2 = $this->factory->user->create();
+
+        wp_set_current_user( $u1 );
+        $_POST = [
+            'nonce'      => wp_create_nonce( 'wpam_place_bid' ),
+            'auction_id' => $auction_id,
+            'bid'        => 10,
+        ];
+        try { $this->_handleAjax( 'wpam_place_bid' ); } catch ( WPAjaxDieContinueException $e ) {}
+
+        wp_set_current_user( $u2 );
+        $_POST = [
+            'nonce'      => wp_create_nonce( 'wpam_place_bid' ),
+            'auction_id' => $auction_id,
+            'bid'        => 10,
+        ];
+        try {
+            $this->_handleAjax( 'wpam_place_bid' );
+        } catch ( WPAjaxDieContinueException $e ) {
+            $response = json_decode( $this->_last_response, true );
+            $this->assertFalse( $response['success'] );
+            $this->assertSame( 'Bid too low', $response['data']['message'] );
+            return;
+        }
+        $this->fail( 'Expected AJAX die.' );
+    }
+
+    public function test_proxy_max_bid_reached() {
+        update_option( 'wpam_enable_proxy_bidding', 1 );
+        $auction_id = $this->factory->post->create([
+            'post_type' => 'product',
+        ]);
+        update_post_meta( $auction_id, '_auction_start', date( 'Y-m-d H:i:s', time() - 3600 ) );
+        update_post_meta( $auction_id, '_auction_end', date( 'Y-m-d H:i:s', time() + 3600 ) );
+        update_post_meta( $auction_id, '_auction_proxy_bidding', 1 );
+
+        $u1 = $this->factory->user->create();
+        $u2 = $this->factory->user->create();
+
+        wp_set_current_user( $u1 );
+        $_POST = [
+            'nonce'      => wp_create_nonce( 'wpam_place_bid' ),
+            'auction_id' => $auction_id,
+            'bid'        => 10,
+            'max_bid'    => 100,
+        ];
+        try { $this->_handleAjax( 'wpam_place_bid' ); } catch ( WPAjaxDieContinueException $e ) {}
+
+        wp_set_current_user( $u2 );
+        $_POST = [
+            'nonce'      => wp_create_nonce( 'wpam_place_bid' ),
+            'auction_id' => $auction_id,
+            'bid'        => 20,
+            'max_bid'    => 20,
+        ];
+        try {
+            $this->_handleAjax( 'wpam_place_bid' );
+        } catch ( WPAjaxDieContinueException $e ) {
+            $response = json_decode( $this->_last_response, true );
+            $this->assertTrue( $response['success'] );
+            $this->assertSame( 'Max bid reached', $response['data']['message'] );
+            $this->assertTrue( $response['data']['max_reached'] );
+            return;
+        }
+        $this->fail( 'Expected AJAX die.' );
+    }
+
+    public function test_sealed_allows_only_one_bid() {
+        $auction_id = $this->factory->post->create([
+            'post_type' => 'product',
+        ]);
+        update_post_meta( $auction_id, '_auction_start', date( 'Y-m-d H:i:s', time() - 3600 ) );
+        update_post_meta( $auction_id, '_auction_end', date( 'Y-m-d H:i:s', time() + 3600 ) );
+        update_post_meta( $auction_id, '_auction_type', 'sealed' );
+
+        $u1 = $this->factory->user->create();
+        wp_set_current_user( $u1 );
+
+        $_POST = [
+            'nonce'      => wp_create_nonce( 'wpam_place_bid' ),
+            'auction_id' => $auction_id,
+            'bid'        => 10,
+        ];
+        try { $this->_handleAjax( 'wpam_place_bid' ); } catch ( WPAjaxDieContinueException $e ) {}
+
+        $_POST = [
+            'nonce'      => wp_create_nonce( 'wpam_place_bid' ),
+            'auction_id' => $auction_id,
+            'bid'        => 20,
+        ];
+        try {
+            $this->_handleAjax( 'wpam_place_bid' );
+        } catch ( WPAjaxDieContinueException $e ) {
+            $response = json_decode( $this->_last_response, true );
+            $this->assertFalse( $response['success'] );
+            $this->assertSame( 'Only one bid allowed for sealed auctions', $response['data']['message'] );
+            return;
+        }
+        $this->fail( 'Expected AJAX die.' );
+    }
+
+    public function test_silent_status_hidden() {
+        update_option( 'wpam_enable_silent_bidding', 1 );
+        $auction_id = $this->factory->post->create([
+            'post_type' => 'product',
+        ]);
+        update_post_meta( $auction_id, '_auction_start', date( 'Y-m-d H:i:s', time() - 3600 ) );
+        update_post_meta( $auction_id, '_auction_end', date( 'Y-m-d H:i:s', time() + 3600 ) );
+        update_post_meta( $auction_id, '_auction_silent_bidding', 1 );
+
+        $u1 = $this->factory->user->create();
+        wp_set_current_user( $u1 );
+
+        $_POST = [
+            'nonce'      => wp_create_nonce( 'wpam_place_bid' ),
+            'auction_id' => $auction_id,
+            'bid'        => 10,
+        ];
+        try {
+            $this->_handleAjax( 'wpam_place_bid' );
+        } catch ( WPAjaxDieContinueException $e ) {
+            $response = json_decode( $this->_last_response, true );
+            $this->assertTrue( $response['success'] );
+            $this->assertSame( [], $response['data']['statuses'] );
+            $this->assertSame( '', $response['data']['status'] );
+            return;
+        }
+        $this->fail( 'Expected AJAX die.' );
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce `BidStrategyInterface` and concrete strategies for standard, proxy, silent, and sealed bidding
- Refactor `WPAM_Bid::place_bid()` to delegate bid handling to strategy classes and invoke soft-close afterwards
- Add unit tests covering standard, proxy max-bid, sealed one-bid limit, and silent visibility

## Testing
- `php -l includes/bidding/BidStrategyInterface.php`
- `php -l includes/bidding/StandardStrategy.php`
- `php -l includes/bidding/ProxyStrategy.php`
- `php -l includes/bidding/SilentStrategy.php`
- `php -l includes/bidding/SealedStrategy.php`
- `php -l includes/class-wpam-bid.php`
- `php -l tests/test-bid-strategies.php`
- `./vendor/bin/phpunit --bootstrap tests/bootstrap.php --testdox` *(failed: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_688e95fadc64833381398026e3299ec8