### PR TITLE
Add relist limit and count tracking

### DIFF
--- a/admin/class-wpam-admin.php
+++ b/admin/class-wpam-admin.php
@@ -37,7 +37,8 @@ class WPAM_Admin {
 
 	public function register_settings() {
                register_setting( 'wpam_settings', 'wpam_default_increment', array( 'sanitize_callback' => array( $this, 'sanitize_decimal' ) ) );
-		register_setting( 'wpam_settings', 'wpam_soft_close', array( 'sanitize_callback' => 'absint' ) );
+               register_setting( 'wpam_settings', 'wpam_default_relist_limit', array( 'sanitize_callback' => 'absint' ) );
+               register_setting( 'wpam_settings', 'wpam_soft_close', array( 'sanitize_callback' => 'absint' ) );
 		register_setting( 'wpam_settings', 'wpam_enable_twilio', array( 'sanitize_callback' => 'rest_sanitize_boolean' ) );
 		register_setting( 'wpam_settings', 'wpam_lead_sms_alerts', array( 'sanitize_callback' => 'rest_sanitize_boolean' ) );
 		register_setting( 'wpam_settings', 'wpam_enable_firebase', array( 'sanitize_callback' => 'rest_sanitize_boolean' ) );
@@ -84,7 +85,9 @@ class WPAM_Admin {
 
 		add_settings_field( 'wpam_max_extensions', __( 'Maximum Extensions', 'wpam' ), array( $this, 'field_max_extensions' ), 'wpam_settings', 'wpam_general' );
 
-		add_settings_field( 'wpam_default_increment', __( 'Default Bid Increment', 'wpam' ), array( $this, 'field_default_increment' ), 'wpam_settings', 'wpam_general' );
+               add_settings_field( 'wpam_default_increment', __( 'Default Bid Increment', 'wpam' ), array( $this, 'field_default_increment' ), 'wpam_settings', 'wpam_general' );
+
+               add_settings_field( 'wpam_default_relist_limit', __( 'Default Relist Limit', 'wpam' ), array( $this, 'field_default_relist_limit' ), 'wpam_settings', 'wpam_general' );
 
 		add_settings_field( 'wpam_soft_close', __( 'Soft Close Duration (minutes)', 'wpam' ), array( $this, 'field_soft_close' ), 'wpam_settings', 'wpam_general' );
 
@@ -237,10 +240,15 @@ class WPAM_Admin {
 		echo '<input type="number" class="small-text" name="wpam_max_extensions" value="' . $value . '" />';
 	}
 
-	public function field_default_increment() {
-		$value = esc_attr( get_option( 'wpam_default_increment', 1 ) );
-		echo '<input type="number" step="0.01" class="small-text" name="wpam_default_increment" value="' . $value . '" />';
-	}
+       public function field_default_increment() {
+               $value = esc_attr( get_option( 'wpam_default_increment', 1 ) );
+               echo '<input type="number" step="0.01" class="small-text" name="wpam_default_increment" value="' . $value . '" />';
+       }
+
+       public function field_default_relist_limit() {
+               $value = esc_attr( get_option( 'wpam_default_relist_limit', 0 ) );
+               echo '<input type="number" class="small-text" name="wpam_default_relist_limit" value="' . $value . '" />';
+       }
 
 	public function field_soft_close() {
 		$value = esc_attr( get_option( 'wpam_soft_close', 0 ) );
@@ -618,15 +626,19 @@ class WPAM_Admin {
         }
 
         private function get_setting_definitions() {
-                return array(
-                       'wpam_default_increment'   => array(
+               return array(
+                      'wpam_default_increment'   => array(
                                'sanitize' => array( $this, 'sanitize_decimal' ),
                                'schema'   => array( 'type' => 'number' ),
                        ),
-                        'wpam_soft_close'          => array(
-                                'sanitize' => 'absint',
-                                'schema'   => array( 'type' => 'integer' ),
-                        ),
+                       'wpam_default_relist_limit' => array(
+                               'sanitize' => 'absint',
+                               'schema'   => array( 'type' => 'integer' ),
+                       ),
+                       'wpam_soft_close'          => array(
+                               'sanitize' => 'absint',
+                               'schema'   => array( 'type' => 'integer' ),
+                       ),
                         'wpam_enable_twilio'       => array(
                                 'sanitize' => 'rest_sanitize_boolean',
                                 'schema'   => array( 'type' => 'boolean' ),

--- a/tests/auction-lifecycle/test-relist-count.php
+++ b/tests/auction-lifecycle/test-relist-count.php
@@ -1,0 +1,39 @@
+<?php
+use WPAM\Includes\WPAM_Auction;
+use WPAM\Includes\WPAM_Auction_State;
+
+class Test_Auction_Relist_Count extends WP_UnitTestCase {
+    protected $auction;
+
+    public function set_up(): void {
+        parent::set_up();
+        $this->auction = new WPAM_Auction();
+    }
+
+    public function test_relist_stops_at_limit() {
+        $auction_id = $this->factory->post->create([
+            'post_type' => 'product',
+        ]);
+        update_post_meta( $auction_id, '_auction_auto_relist', 1 );
+        update_post_meta( $auction_id, '_auction_relist_limit', 1 );
+        update_post_meta( $auction_id, '_auction_relist_count', 0 );
+        update_post_meta( $auction_id, '_auction_start', date( 'Y-m-d H:i:s', time() - 7200 ) );
+        update_post_meta( $auction_id, '_auction_end', date( 'Y-m-d H:i:s', time() - 3600 ) );
+
+        $this->auction->handle_auction_end( $auction_id );
+
+        $this->assertSame( 'scheduled', get_post_meta( $auction_id, '_auction_status', true ) );
+        $this->assertSame( WPAM_Auction_State::SCHEDULED, get_post_meta( $auction_id, '_auction_state', true ) );
+        $this->assertSame( '1', get_post_meta( $auction_id, '_auction_relist_count', true ) );
+
+        // Simulate the relisted auction ending again.
+        update_post_meta( $auction_id, '_auction_start', date( 'Y-m-d H:i:s', time() - 7200 ) );
+        update_post_meta( $auction_id, '_auction_end', date( 'Y-m-d H:i:s', time() - 3600 ) );
+
+        $this->auction->handle_auction_end( $auction_id );
+
+        $this->assertSame( 'failed', get_post_meta( $auction_id, '_auction_status', true ) );
+        $this->assertSame( WPAM_Auction_State::FAILED, get_post_meta( $auction_id, '_auction_state', true ) );
+        $this->assertSame( '1', get_post_meta( $auction_id, '_auction_relist_count', true ) );
+    }
+}


### PR DESCRIPTION
## Summary
- track how many times an auction relists and limit it based on a configurable value
- expose default relist limit in settings
- test relist count behavior

## Testing
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` (fails: Error establishing a database connection)


------
https://chatgpt.com/codex/tasks/task_e_688e9b41f9a8833391ee94871d8f9a2e