### PR TITLE
Add relist scheduling options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,4 +24,5 @@
 - Introduced skeleton WebSocket provider classes for future realtime support.
 - Added admin settings to select a realtime provider and enter Pusher credentials.
 - Bundled Pusher and Countdown scripts and switched enqueues to local assets.
+- Added relist delay and price adjustment options for automatic relists.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ When editing an auction product you can configure additional options in the **Au
 - **Minimum Increment** – smallest allowed increase between bids.
 - **Soft Close Threshold** – number of seconds before closing when bids will extend the auction.
 - **Extension Duration** – seconds added to the end time when the threshold is triggered.
-- **Auto Relist** – automatically relist when no winning bid exists.
+- **Auto Relist** – automatically relist when no winning bid exists. Configure a relist limit, delay before relisting and optional price adjustments.
 - **Max Bids Per User** – limit how many bids each user can place.
 - **Auction Fee** – extra fee added to the winning bid.
 - **Proxy Bidding** – automatically outbid others up to a maximum amount.

--- a/admin/class-wpam-admin.php
+++ b/admin/class-wpam-admin.php
@@ -356,8 +356,9 @@ class WPAM_Admin {
 			wp_enqueue_style( 'flatpickr', WPAM_PLUGIN_URL . 'assets/admin/css/flatpickr.min.css', array(), WPAM_PLUGIN_VERSION );
 			wp_enqueue_script( 'flatpickr', WPAM_PLUGIN_URL . 'assets/admin/js/flatpickr.min.js', array(), WPAM_PLUGIN_VERSION, true );
 			wp_enqueue_script( 'wpam-date-picker', WPAM_PLUGIN_URL . 'assets/admin/js/auction-date-picker.js', array( 'jquery', 'flatpickr' ), WPAM_PLUGIN_VERSION, true );
-			wp_enqueue_script( 'wpam-auction-type-toggle', WPAM_PLUGIN_URL . 'assets/admin/js/auction-type-toggle.js', array( 'jquery' ), WPAM_PLUGIN_VERSION, true );
-		}
+                       wp_enqueue_script( 'wpam-auction-type-toggle', WPAM_PLUGIN_URL . 'assets/admin/js/auction-type-toggle.js', array( 'jquery' ), WPAM_PLUGIN_VERSION, true );
+                       wp_enqueue_script( 'wpam-auction-relist-options', WPAM_PLUGIN_URL . 'assets/admin/js/auction-relist-options.js', array( 'jquery' ), WPAM_PLUGIN_VERSION, true );
+               }
 
 		$slug        = 'auctions';
 		$admin_pages = array(

--- a/assets/admin/js/auction-relist-options.js
+++ b/assets/admin/js/auction-relist-options.js
@@ -1,0 +1,12 @@
+jQuery(function($){
+    var relistFields = $('._auction_relist_limit_field, ._auction_relist_delay_field, ._auction_relist_price_adjustment_field');
+    function toggleRelist(){
+        if($('#_auction_auto_relist').is(':checked')){
+            relistFields.show();
+        } else {
+            relistFields.hide();
+        }
+    }
+    $('#_auction_auto_relist').on('change', toggleRelist);
+    toggleRelist();
+});

--- a/languages/wp-auction-manager.pot
+++ b/languages/wp-auction-manager.pot
@@ -60,3 +60,34 @@ msgstr ""
 #: includes/class-wpam-auction.php
 msgid "Reserve price not met"
 msgstr ""
+#: includes/class-wpam-auction.php
+msgid "Auto Relist"
+msgstr ""
+
+#: includes/class-wpam-auction.php
+msgid "Relist automatically when there is no winner. Additional options appear when enabled."
+msgstr ""
+
+#: includes/class-wpam-auction.php
+msgid "Relist Limit"
+msgstr ""
+
+#: includes/class-wpam-auction.php
+msgid "Maximum number of times to relist automatically."
+msgstr ""
+
+#: includes/class-wpam-auction.php
+msgid "Relist Delay (minutes)"
+msgstr ""
+
+#: includes/class-wpam-auction.php
+msgid "Minutes to wait before relisting."
+msgstr ""
+
+#: includes/class-wpam-auction.php
+msgid "Price Adjustment"
+msgstr ""
+
+#: includes/class-wpam-auction.php
+msgid "Amount to adjust starting price on each relist. Can be negative."
+msgstr ""


### PR DESCRIPTION
## Summary
- add relist limit, delay and price adjustment fields to auction admin
- toggle relist options via new admin script
- document new relist controls

## Testing
- `vendor/bin/phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_688e9d1c61688333b963b48d32e72068