### PR TITLE
Verify Pusher credentials and show status in settings

### DIFF
--- a/admin/class-wpam-admin.php
+++ b/admin/class-wpam-admin.php
@@ -576,17 +576,20 @@ class WPAM_Admin {
 			);
 	}
 
-	public function rest_get_settings( \WP_REST_Request $request ) {
-		$options = array();
-		foreach ( $this->get_option_keys() as $key ) {
-			$options[ $key ] = get_option( $key );
-		}
+        public function rest_get_settings( \WP_REST_Request $request ) {
+                $options = array();
+                foreach ( $this->get_option_keys() as $key ) {
+                        $options[ $key ] = get_option( $key );
+                }
 
-		return rest_ensure_response( $options );
-	}
+                $options['wpam_pusher_status'] = get_option( 'wpam_pusher_status', 'disabled' );
+
+                return rest_ensure_response( $options );
+        }
 
         public function rest_update_settings( \WP_REST_Request $request ) {
                 $params  = $request->get_json_params();
+                unset( $params['wpam_pusher_status'] );
                 $errors  = array();
                 $defines = $this->get_setting_definitions();
 

--- a/assets/admin/js/settings-app.js
+++ b/assets/admin/js/settings-app.js
@@ -269,10 +269,11 @@
       setSaving(true);
       setNotice(''); // Clear previous notices
 
+      const { wpam_pusher_status, ...toSave } = settings;
       apiFetch({
         path: wpamSettings.rest_endpoint,
         method: 'POST',
-        data: settings,
+        data: toSave,
         headers: { 'X-WP-Nonce': wpamSettings.nonce },
       })
         .then((response) => {
@@ -462,9 +463,20 @@
     }
 
     function renderRealtime() {
+      const statusMap = {
+        connected: 'Connected',
+        invalid: 'Invalid credentials',
+        disabled: 'Disabled',
+      };
+      const status = statusMap[settings.wpam_pusher_status] || 'Unknown';
       return createElement(
         'div',
         null,
+        createElement(
+          'p',
+          { className: 'wpam-pusher-status' },
+          'Status: ' + status
+        ),
         createElement(SelectControl, {
           label: 'Realtime Provider',
           help: 'Service used for realtime updates.',

--- a/includes/api-integrations/class-pusher-provider.php
+++ b/includes/api-integrations/class-pusher-provider.php
@@ -52,6 +52,20 @@ class WPAM_Pusher_Provider implements WPAM_Realtime_Provider {
                     'useTLS'  => true,
                 ]
             );
+            try {
+                $this->pusher->get_channels();
+                update_option( 'wpam_pusher_status', 'connected' );
+            } catch ( \Exception $e ) {
+                $this->pusher = null;
+                update_option( 'wpam_pusher_status', 'invalid' );
+                update_option( 'wpam_realtime_provider', 'none' );
+                add_action( 'admin_notices', function() {
+                    echo '<div class="notice notice-error"><p>' . esc_html__( 'Invalid Pusher credentials. Realtime features have been disabled.', 'wpam' ) . '</p></div>';
+                } );
+            }
+        } else {
+            update_option( 'wpam_pusher_status', 'invalid' );
+            update_option( 'wpam_realtime_provider', 'none' );
         }
     }
 

--- a/includes/class-wpam-loader.php
+++ b/includes/class-wpam-loader.php
@@ -16,6 +16,8 @@ class WPAM_Loader {
                 if ( $pusher_provider->is_active() ) {
                         WPAM_Event_Bus::register( $pusher_provider );
                 }
+        } else {
+                update_option( 'wpam_pusher_status', 'disabled' );
         }
 
         new WPAM_Auction();


### PR DESCRIPTION
## Summary
- Validate Pusher credentials on construction and fall back to disabled realtime with an admin notice when verification fails
- Expose Pusher connection status via REST and display it in the settings UI
- Prevent saving the derived status field when updating settings

## Testing
- `npm test` *(fails: Missing script "test")*
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_688ea0463b308333961c4bdec7ee6c47