### PR TITLE
Add auction status data attributes and refine countdown

### DIFF
--- a/includes/class-wpam-html.php
+++ b/includes/class-wpam-html.php
@@ -45,15 +45,15 @@ class WPAM_HTML {
     $display_highest = ( $silent && $now < $end_ts ) ? __( 'Hidden', 'wpam' ) : wc_price( $highest );
 
     ob_start();
-    echo '<div class="wpam-auction-block theme-1">';
+    echo '<div class="wpam-auction-block theme-1" data-status="' . esc_attr( $status ) . '" data-start="' . esc_attr( $start_ts ) . '" data-end="' . esc_attr( $end_ts ) . '">';
     
     if ( $atts['showStatus'] ) {
       echo '<p class="wpam-status auction-status">' . esc_html( ucfirst( $status ) ) . '</p>';
       echo '<p class="wpam-type">' . esc_html( ucfirst( $type ) ) . '</p>';
     }
 
-    if ( $atts['showCountdown'] ) {
-      echo '<p class="wpam-countdown" data-start="' . esc_attr( $start_ts ) . '" data-end="' . esc_attr( $end_ts ) . '"></p>';
+    if ( $atts['showCountdown'] && ! in_array( $status, [ 'ended', 'canceled', 'suspended' ], true ) ) {
+      echo '<p class="wpam-countdown" data-start="' . esc_attr( $start_ts ) . '" data-end="' . esc_attr( $end_ts ) . '" data-status="' . esc_attr( $status ) . '"></p>';
     }
 
     $label = ( 'reverse' === $type ) ? __( 'Lowest Bid:', 'wpam' ) : __( 'Current Bid:', 'wpam' );

--- a/templates/single-auction.php
+++ b/templates/single-auction.php
@@ -1,17 +1,18 @@
 <?php
 get_header();
+$start          = get_post_meta( get_the_ID(), '_auction_start', true );
+$start_ts       = $start ? ( new \DateTimeImmutable( $start, new \DateTimeZone( 'UTC' ) ) )->getTimestamp() : 0;
+$end            = get_post_meta( get_the_ID(), '_auction_end', true );
+$end_ts         = $end ? ( new \DateTimeImmutable( $end, new \DateTimeZone( 'UTC' ) ) )->getTimestamp() : 0;
+$status         = get_post_meta( get_the_ID(), '_auction_state', true );
+$buy_now_enabled = get_post_meta( get_the_ID(), '_auction_enable_buy_now', true );
+$buy_now_price   = get_post_meta( get_the_ID(), '_auction_buy_now', true );
 ?>
-<div class="auction-single">
+<div class="auction-single" data-status="<?php echo esc_attr( $status ); ?>" data-start="<?php echo esc_attr( $start_ts ); ?>" data-end="<?php echo esc_attr( $end_ts ); ?>">
     <h1><?php the_title(); ?></h1>
-    <?php
-    $start    = get_post_meta( get_the_ID(), '_auction_start', true );
-    $start_ts = $start ? ( new \DateTimeImmutable( $start, new \DateTimeZone( 'UTC' ) ) )->getTimestamp() : 0;
-    $end      = get_post_meta( get_the_ID(), '_auction_end', true );
-    $end_ts   = $end ? ( new \DateTimeImmutable( $end, new \DateTimeZone( 'UTC' ) ) )->getTimestamp() : 0;
-    $buy_now_enabled = get_post_meta( get_the_ID(), '_auction_enable_buy_now', true );
-    $buy_now_price   = get_post_meta( get_the_ID(), '_auction_buy_now', true );
-    ?>
-    <p class="wpam-countdown" data-start="<?php echo esc_attr( $start_ts ); ?>" data-end="<?php echo esc_attr( $end_ts ); ?>"></p>
+    <?php if ( ! in_array( $status, [ 'ended', 'canceled', 'suspended' ], true ) ) : ?>
+        <p class="wpam-countdown" data-start="<?php echo esc_attr( $start_ts ); ?>" data-end="<?php echo esc_attr( $end_ts ); ?>" data-status="<?php echo esc_attr( $status ); ?>"></p>
+    <?php endif; ?>
     <form class="wpam-bid-form">
         <input type="number" step="0.01" class="wpam-bid-input" />
         <?php wp_nonce_field( 'wpam_place_bid', 'wpam_bid_nonce', false ); ?>

--- a/tests/test-html-countdown.php
+++ b/tests/test-html-countdown.php
@@ -1,0 +1,38 @@
+<?php
+use WPAM\Includes\WPAM_HTML;
+
+class Test_HTML_Countdown extends WP_UnitTestCase {
+    public function test_countdown_skipped_for_inactive_status() {
+        $auction_id = $this->factory->post->create([
+            'post_type' => 'product',
+        ]);
+        update_post_meta( $auction_id, '_auction_start', date( 'Y-m-d H:i:s', time() - 3600 ) );
+        update_post_meta( $auction_id, '_auction_end', date( 'Y-m-d H:i:s', time() + 3600 ) );
+        update_post_meta( $auction_id, '_auction_type', 'normal' );
+        update_post_meta( $auction_id, '_auction_state', 'ended' );
+
+        $html = WPAM_HTML::render_auction_meta( $auction_id );
+
+        $this->assertStringNotContainsString( 'wpam-countdown', $html );
+        $this->assertStringContainsString( 'data-status="ended"', $html );
+        $this->assertStringContainsString( 'data-start="', $html );
+        $this->assertStringContainsString( 'data-end="', $html );
+    }
+
+    public function test_countdown_shown_for_active_status() {
+        $auction_id = $this->factory->post->create([
+            'post_type' => 'product',
+        ]);
+        update_post_meta( $auction_id, '_auction_start', date( 'Y-m-d H:i:s', time() - 3600 ) );
+        update_post_meta( $auction_id, '_auction_end', date( 'Y-m-d H:i:s', time() + 3600 ) );
+        update_post_meta( $auction_id, '_auction_type', 'normal' );
+        update_post_meta( $auction_id, '_auction_state', 'active' );
+
+        $html = WPAM_HTML::render_auction_meta( $auction_id );
+
+        $this->assertStringContainsString( 'class="wpam-countdown"', $html );
+        $this->assertStringContainsString( 'data-status="active"', $html );
+        $this->assertStringContainsString( 'data-start="', $html );
+        $this->assertStringContainsString( 'data-end="', $html );
+    }
+}


### PR DESCRIPTION
## Summary
- add data-status, data-start, and data-end attributes to auction meta markup
- hide countdown for ended, canceled, or suspended auctions
- test HTML rendering for active vs inactive statuses

## Testing
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php` *(fails: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_688f48774228833380afa6692d033fe6