### PR TITLE
fix: ensure countdown updates render immediately

### DIFF
--- a/public/js/ajax-bid.js
+++ b/public/js/ajax-bid.js
@@ -20,6 +20,7 @@ jQuery(function ($) {
       cd.status = status;
       cd.$el.data('status', status).attr('data-status', status);
     }
+    cd.last = 0;
   }
 
   function startCountdowns() {


### PR DESCRIPTION
## Summary
- reset cached countdown timer after updates for immediate rerender

## Testing
- `npm test` *(fails: Missing script "test")*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688f516745f88333a9c1e2826da4ed47