### PR TITLE
Expose auction timing in highest bid endpoint

### DIFF
--- a/includes/class-wpam-bid.php
+++ b/includes/class-wpam-bid.php
@@ -304,23 +304,31 @@ class WPAM_Bid {
         $highest = $highest ? ( function_exists( 'wc_format_decimal' ) ? (float) wc_format_decimal( $highest ) : (float) $highest ) : 0;
         $lead_user = intval( get_post_meta( $auction_id, '_auction_lead_user', true ) );
 
-        $lead_user = intval( get_post_meta( $auction_id, '_auction_lead_user', true ) );
+        $start    = get_post_meta( $auction_id, '_auction_start', true );
+        $end      = get_post_meta( $auction_id, '_auction_end', true );
+        $start_ts = $start ? ( new \DateTimeImmutable( $start, new \DateTimeZone( 'UTC' ) ) )->getTimestamp() : 0;
+        $end_ts   = $end ? ( new \DateTimeImmutable( $end, new \DateTimeZone( 'UTC' ) ) )->getTimestamp() : 0;
+        $state    = get_post_meta( $auction_id, '_auction_state', true );
 
         if ( $sealed || self::silent_enabled( $auction_id ) ) {
-            $end    = get_post_meta( $auction_id, '_auction_end', true );
-            $end_ts = $end ? ( new \DateTimeImmutable( $end, new \DateTimeZone( 'UTC' ) ) )->getTimestamp() : 0;
             if ( current_datetime()->getTimestamp() < $end_ts ) {
-                $highest  = 0;
+                $highest   = 0;
                 $lead_user = 0;
             }
         }
 
         $ending_reason = '';
-        if ( WPAM_Auction_State::ENDED === get_post_meta( $auction_id, '_auction_state', true ) ) {
+        if ( WPAM_Auction_State::ENDED === $state ) {
             $ending_reason = get_post_meta( $auction_id, '_auction_ending_reason', true );
         }
 
-        $response = [ 'highest_bid' => $highest, 'lead_user' => $lead_user ];
+        $response = [
+            'highest_bid' => $highest,
+            'lead_user'   => $lead_user,
+            'start_ts'    => $start_ts,
+            'end_ts'      => $end_ts,
+            'state'       => $state,
+        ];
         if ( $ending_reason ) {
             $response['ending_reason'] = $ending_reason;
         }

--- a/public/js/ajax-bid.js
+++ b/public/js/ajax-bid.js
@@ -287,17 +287,24 @@ jQuery(function ($) {
               showToast(i18n.reserve_not_met || 'Reserve price not met', 'warning');
               bidStatus[auctionId + '_reserve'] = true;
             }
-            if (
-              res.data.new_start_ts ||
-              res.data.new_end_ts ||
-              res.data.new_status
-            ) {
+            if (res.data.start_ts || res.data.end_ts || res.data.state) {
               updateCountdown(
                 auctionId,
-                res.data.new_start_ts,
-                res.data.new_end_ts,
-                res.data.new_status
+                res.data.start_ts,
+                res.data.end_ts,
+                res.data.state
               );
+              const container = bidEl.closest(
+                '.auction-single, .wpam-auction-block'
+              );
+              if (container.length) {
+                if (res.data.state)
+                  container.attr('data-status', res.data.state);
+                if (res.data.start_ts)
+                  container.attr('data-start', res.data.start_ts);
+                if (res.data.end_ts)
+                  container.attr('data-end', res.data.end_ts);
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary
- return auction start, end and state with highest bid
- refresh bids to update countdown and container status when timing or state changes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `vendor/bin/phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_688f54623ca4833389975a8bfdcc5f4d