### PR TITLE
Expose timing and state data in highest bid endpoint

### DIFF
--- a/includes/class-wpam-bid.php
+++ b/includes/class-wpam-bid.php
@@ -320,7 +320,19 @@ class WPAM_Bid {
             $ending_reason = get_post_meta( $auction_id, '_auction_ending_reason', true );
         }
 
-        $response = [ 'highest_bid' => $highest, 'lead_user' => $lead_user ];
+        $start    = get_post_meta( $auction_id, '_auction_start', true );
+        $end      = get_post_meta( $auction_id, '_auction_end', true );
+        $start_ts = $start ? ( new \DateTimeImmutable( $start, new \DateTimeZone( 'UTC' ) ) )->getTimestamp() : 0;
+        $end_ts   = $end ? ( new \DateTimeImmutable( $end, new \DateTimeZone( 'UTC' ) ) )->getTimestamp() : 0;
+        $state    = get_post_meta( $auction_id, '_auction_state', true );
+
+        $response = [
+            'highest_bid' => $highest,
+            'lead_user'   => $lead_user,
+            'start_ts'    => $start_ts,
+            'end_ts'      => $end_ts,
+            'state'       => $state,
+        ];
         if ( $ending_reason ) {
             $response['ending_reason'] = $ending_reason;
         }

--- a/public/js/ajax-bid.js
+++ b/public/js/ajax-bid.js
@@ -287,16 +287,12 @@ jQuery(function ($) {
               showToast(i18n.reserve_not_met || 'Reserve price not met', 'warning');
               bidStatus[auctionId + '_reserve'] = true;
             }
-            if (
-              res.data.new_start_ts ||
-              res.data.new_end_ts ||
-              res.data.new_status
-            ) {
+            if (res.data.start_ts || res.data.end_ts || res.data.state) {
               updateCountdown(
                 auctionId,
-                res.data.new_start_ts,
-                res.data.new_end_ts,
-                res.data.new_status
+                res.data.start_ts,
+                res.data.end_ts,
+                res.data.state
               );
             }
           }


### PR DESCRIPTION
## Summary
- include auction start/end timestamps and state in highest bid Ajax endpoint
- refresh frontend bid polling to update countdown using start/end/state

## Testing
- `npm test` *(fails: Missing script "test")*
- `composer install`
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_688f6c5f08148333b58f782b9d7615d0