### PR TITLE
Fix scheduled auction events to use UTC and reschedule on upgrade

### DIFF
--- a/includes/class-wpam-install.php
+++ b/includes/class-wpam-install.php
@@ -141,15 +141,19 @@ class WPAM_Install {
 
                        $start_ts = $start ? ( new \DateTimeImmutable( $start, new \DateTimeZone( 'UTC' ) ) )->getTimestamp() : false;
                        $end_ts   = $end ? ( new \DateTimeImmutable( $end, new \DateTimeZone( 'UTC' ) ) )->getTimestamp() : false;
-                       $now      = current_time( 'timestamp' );
+                       $now      = current_datetime()->getTimestamp();
 
-			if ( $start_ts && $start_ts > $now ) {
-				wp_schedule_single_event( $start_ts, 'wpam_auction_start', array( $auction_id ) );
-			}
+                        // Clear previously scheduled events to ensure accurate timing after upgrades.
+                        wp_clear_scheduled_hook( 'wpam_auction_start', array( $auction_id ) );
+                        wp_clear_scheduled_hook( 'wpam_auction_end', array( $auction_id ) );
 
-			if ( $end_ts && $end_ts > $now ) {
-				wp_schedule_single_event( $end_ts, 'wpam_auction_end', array( $auction_id ) );
-			}
+                        if ( $start_ts && $start_ts > $now ) {
+                                wp_schedule_single_event( $start_ts, 'wpam_auction_start', array( $auction_id ) );
+                        }
+
+                        if ( $end_ts && $end_ts > $now ) {
+                                wp_schedule_single_event( $end_ts, 'wpam_auction_end', array( $auction_id ) );
+                        }
 		}
 	}
 }

--- a/tests/test-schedule-upgrade.php
+++ b/tests/test-schedule-upgrade.php
@@ -1,0 +1,35 @@
+<?php
+use WPAM\Includes\WPAM_Install;
+
+class Test_WPAM_Install_Schedule extends WP_UnitTestCase {
+    public function test_reschedules_pending_events() {
+        WPAM_Install::activate();
+
+        $auction_id = $this->factory->post->create([
+            'post_type' => 'product',
+        ]);
+
+        $start = gmdate( 'Y-m-d H:i:s', time() + 3600 );
+        $end   = gmdate( 'Y-m-d H:i:s', time() + 7200 );
+        update_post_meta( $auction_id, '_auction_start', $start );
+        update_post_meta( $auction_id, '_auction_end', $end );
+
+        // Schedule incorrect timestamps to mimic previous offset behaviour.
+        $wrong_start = time() + 1800;
+        $wrong_end   = time() + 5400;
+        wp_schedule_single_event( $wrong_start, 'wpam_auction_start', [ $auction_id ] );
+        wp_schedule_single_event( $wrong_end, 'wpam_auction_end', [ $auction_id ] );
+
+        // Activation should clear and reschedule events using UTC.
+        WPAM_Install::activate();
+
+        $scheduled_start = wp_next_scheduled( 'wpam_auction_start', [ $auction_id ] );
+        $scheduled_end   = wp_next_scheduled( 'wpam_auction_end', [ $auction_id ] );
+
+        $expected_start = ( new DateTimeImmutable( $start, new DateTimeZone( 'UTC' ) ) )->getTimestamp();
+        $expected_end   = ( new DateTimeImmutable( $end, new DateTimeZone( 'UTC' ) ) )->getTimestamp();
+
+        $this->assertSame( $expected_start, $scheduled_start );
+        $this->assertSame( $expected_end, $scheduled_end );
+    }
+}


### PR DESCRIPTION
## Summary
- use `current_datetime()` for UTC-safe scheduling in installer
- clear and reschedule auction start/end events on upgrade
- add test covering rescheduling behavior

## Testing
- `HTTP_HOST=example.org ./vendor/bin/phpunit --bootstrap tests/bootstrap.php --test-suffix=.php tests` *(fails: no output, likely due to test configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688f9f1fd8108333adb04e1d7e43ef98