### PR TITLE
Use epoch-based timers for countdown render

### DIFF
--- a/public/js/ajax-bid.js
+++ b/public/js/ajax-bid.js
@@ -76,7 +76,8 @@ jQuery(function ($) {
         `);
     }
 
-    function render(now) {
+    function render() {
+      const now = Date.now();
       Object.values(countdowns).forEach((cd) => {
         const currentStatus = cd.$el.data('status');
         if (currentStatus !== cd.status) {
@@ -113,10 +114,10 @@ jQuery(function ($) {
         cd.$el.html(`<strong>${status ? status.charAt(0).toUpperCase() + status.slice(1) : ''}</strong>`);
       });
 
-      requestAnimationFrame(render);
+      requestAnimationFrame(() => render());
     }
 
-    requestAnimationFrame(render);
+    requestAnimationFrame(() => render());
   }
 
   startCountdowns();


### PR DESCRIPTION
## Summary
- ensure countdown rendering derives current time with `Date.now()`
- wrap animation frame calls to avoid relying on browser-provided timestamps

## Testing
- `TZ=UTC node - <<'NODE' ... NODE`
- `TZ=Pacific/Honolulu node - <<'NODE' ... NODE`
- `vendor/bin/phpunit tests` *(fails: No tests executed)*
- `vendor/bin/phpunit tests/test-bid.php` *(fails: Class "WP_Ajax_UnitTestCase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fa1e2902c8333be5d05635b16386e