### PR TITLE
Handle missing auction dates

### DIFF
--- a/tests/auction-lifecycle/test-status-transitions.php
+++ b/tests/auction-lifecycle/test-status-transitions.php
@@ -52,4 +52,20 @@ class Test_Auction_Status_Transitions extends WP_UnitTestCase {
         $state = $this->auction->determine_state( $auction_id );
         $this->assertSame( WPAM_Auction_State::CANCELED, $state );
     }
+
+    public function test_missing_dates_defaults_to_scheduled() {
+        $auction_id = $this->factory->post->create([
+            'post_type' => 'product',
+        ]);
+
+        remove_all_actions( 'admin_notices' );
+
+        $state = $this->auction->determine_state( $auction_id );
+
+        $this->assertSame( WPAM_Auction_State::SCHEDULED, $state );
+        $this->assertSame( 'scheduled', get_post_meta( $auction_id, '_auction_status', true ) );
+        $this->assertNotFalse( has_action( 'admin_notices' ) );
+
+        remove_all_actions( 'admin_notices' );
+    }
 }


### PR DESCRIPTION
## Summary
- avoid DateTime errors in `determine_state()` by validating auction start/end dates and logging a warning if missing
- add test covering scheduled fallback when dates are absent

## Testing
- `php -l includes/class-wpam-auction.php`
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/auction-lifecycle/test-status-transitions.php` *(fails: Error establishing a database connection)*


------
https://chatgpt.com/codex/tasks/task_e_688fac696acc8333bf8f447850c32fe5