### PR TITLE
Reschedule auctions on upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,4 +25,5 @@
 - Added admin settings to select a realtime provider and enter Pusher credentials.
 - Bundled Pusher and Countdown scripts and switched enqueues to local assets.
 - Added relist delay and price adjustment options for automatic relists.
+- Activation now recalculates start and end times in UTC for existing auctions.
 

--- a/README.md
+++ b/README.md
@@ -188,3 +188,7 @@ composer install
 vendor/bin/phpunit
 vendor/bin/phpcs
 ```
+
+## Upgrade Notes
+
+- Activating or updating the plugin now recalculates existing auction start and end times in UTC and reschedules their events.

--- a/tests/test-schedule-upgrade.php
+++ b/tests/test-schedule-upgrade.php
@@ -32,4 +32,34 @@ class Test_WPAM_Install_Schedule extends WP_UnitTestCase {
         $this->assertSame( $expected_start, $scheduled_start );
         $this->assertSame( $expected_end, $scheduled_end );
     }
+
+    public function test_update_reschedules_pending_events() {
+        WPAM_Install::activate();
+
+        $auction_id = $this->factory->post->create([
+            'post_type' => 'product',
+        ]);
+
+        $start = gmdate( 'Y-m-d H:i:s', time() + 3600 );
+        $end   = gmdate( 'Y-m-d H:i:s', time() + 7200 );
+        update_post_meta( $auction_id, '_auction_start', $start );
+        update_post_meta( $auction_id, '_auction_end', $end );
+
+        $wrong_start = time() + 1800;
+        $wrong_end   = time() + 5400;
+        wp_schedule_single_event( $wrong_start, 'wpam_auction_start', [ $auction_id ] );
+        wp_schedule_single_event( $wrong_end, 'wpam_auction_end', [ $auction_id ] );
+
+        update_option( 'wpam_version', '0.0.1' );
+        wpam_plugins_loaded();
+
+        $scheduled_start = wp_next_scheduled( 'wpam_auction_start', [ $auction_id ] );
+        $scheduled_end   = wp_next_scheduled( 'wpam_auction_end', [ $auction_id ] );
+
+        $expected_start = ( new DateTimeImmutable( $start, new DateTimeZone( 'UTC' ) ) )->getTimestamp();
+        $expected_end   = ( new DateTimeImmutable( $end, new DateTimeZone( 'UTC' ) ) )->getTimestamp();
+
+        $this->assertSame( $expected_start, $scheduled_start );
+        $this->assertSame( $expected_end, $scheduled_end );
+    }
 }

--- a/wp-auction-manager.php
+++ b/wp-auction-manager.php
@@ -89,6 +89,7 @@ function wpam_activation() {
     }
 
     \WPAM\Includes\WPAM_Install::activate();
+    update_option( 'wpam_version', WPAM_PLUGIN_VERSION );
 }
 
 function wpam_run_plugin() {
@@ -136,6 +137,12 @@ function wpam_plugins_loaded() {
     if ( ! class_exists( 'WooCommerce' ) ) {
         add_action( 'admin_notices', 'wpam_wc_missing_notice' );
         return;
+    }
+
+    $installed = get_option( 'wpam_version' );
+    if ( WPAM_PLUGIN_VERSION !== $installed ) {
+        \WPAM\Includes\WPAM_Install::activate();
+        update_option( 'wpam_version', WPAM_PLUGIN_VERSION );
     }
 
     wpam_run_plugin();


### PR DESCRIPTION
## Summary
- Re-run installation routine and auction event scheduling on activation and when plugin version changes
- Note in upgrade docs that activation recalculates start/end times in UTC
- Test scheduling is refreshed after version upgrades

## Testing
- `./vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Error establishing a database connection)*
- `php -d memory_limit=512M vendor/bin/phpcs wp-auction-manager.php tests/test-schedule-upgrade.php` *(fails: numerous coding standard violations)*

------
https://chatgpt.com/codex/tasks/task_e_688fc3045ff883339d9e2949a04054d2