### PR TITLE
Refactor rewrite endpoints registration

### DIFF
--- a/includes/class-wpam-bid.php
+++ b/includes/class-wpam-bid.php
@@ -18,7 +18,6 @@ class WPAM_Bid {
         add_action( 'wp_ajax_wpam_buy_now', [ $this, 'buy_now' ] );
         add_action( 'wp_ajax_nopriv_wpam_buy_now', [ $this, 'buy_now' ] );
 
-        add_action( 'init', [ $this, 'add_account_endpoints' ] );
         add_filter( 'woocommerce_account_menu_items', [ $this, 'add_account_menu_items' ] );
         add_action( 'woocommerce_account_my-bids_endpoint', [ $this, 'render_my_bids_page' ] );
         add_action( 'woocommerce_account_auctions-won_endpoint', [ $this, 'render_auctions_won_page' ] );
@@ -648,11 +647,6 @@ class WPAM_Bid {
         }
 
         return rest_ensure_response( $response );
-    }
-
-    public function add_account_endpoints() {
-        add_rewrite_endpoint( 'my-bids', EP_ROOT | EP_PAGES );
-        add_rewrite_endpoint( 'auctions-won', EP_ROOT | EP_PAGES );
     }
 
     public function add_account_menu_items( $items ) {

--- a/includes/class-wpam-install.php
+++ b/includes/class-wpam-install.php
@@ -2,7 +2,7 @@
 namespace WPAM\Includes;
 
 class WPAM_Install {
-	public static function activate() {
+        public static function activate() {
 		global $wpdb;
 		$charset_collate = $wpdb->get_charset_collate();
 		$table_name      = $wpdb->prefix . 'wc_auction_bids';
@@ -115,10 +115,9 @@ class WPAM_Install {
                         $admin->add_cap( 'auction_bidder' );
                 }
 
-                add_rewrite_endpoint( 'watchlist', EP_ROOT | EP_PAGES );
-		add_rewrite_endpoint( 'my-bids', EP_ROOT | EP_PAGES );
-		add_rewrite_endpoint( 'auctions-won', EP_ROOT | EP_PAGES );
-		flush_rewrite_rules();
+                add_action( 'init', [ self::class, 'register_endpoints' ] );
+                self::register_endpoints();
+                flush_rewrite_rules();
 
 		// Schedule cron events for existing auctions
 		$auctions = get_posts(
@@ -135,7 +134,7 @@ class WPAM_Install {
 			)
 		);
 
-		foreach ( $auctions as $auction_id ) {
+                foreach ( $auctions as $auction_id ) {
 			$start = get_post_meta( $auction_id, '_auction_start', true );
 			$end   = get_post_meta( $auction_id, '_auction_end', true );
 
@@ -151,9 +150,16 @@ class WPAM_Install {
                                 wp_schedule_single_event( $start_ts, 'wpam_auction_start', array( $auction_id ) );
                         }
 
-                        if ( $end_ts && $end_ts > $now ) {
+                if ( $end_ts && $end_ts > $now ) {
                                 wp_schedule_single_event( $end_ts, 'wpam_auction_end', array( $auction_id ) );
-                        }
-		}
-	}
+                }
+                }
+                
+        }
+
+        public static function register_endpoints() {
+                add_rewrite_endpoint( 'watchlist', EP_ROOT | EP_PAGES );
+                add_rewrite_endpoint( 'my-bids', EP_ROOT | EP_PAGES );
+                add_rewrite_endpoint( 'auctions-won', EP_ROOT | EP_PAGES );
+        }
 }

--- a/includes/class-wpam-watchlist.php
+++ b/includes/class-wpam-watchlist.php
@@ -8,7 +8,6 @@ class WPAM_Watchlist {
 
         add_action( 'wp_ajax_wpam_get_watchlist', [ self::class, 'get_watchlist' ] );
 
-        add_action( 'init', [ $this, 'add_account_endpoint' ] );
         add_filter( 'woocommerce_account_menu_items', [ $this, 'add_account_menu_item' ] );
         add_action( 'woocommerce_account_watchlist_endpoint', [ $this, 'render_account_page' ] );
     }
@@ -103,10 +102,6 @@ class WPAM_Watchlist {
         }
 
         return rest_ensure_response( [ 'items' => self::get_user_watchlist_items( $user_id ) ] );
-    }
-
-    public function add_account_endpoint() {
-        add_rewrite_endpoint( 'watchlist', EP_ROOT | EP_PAGES );
     }
 
     public function add_account_menu_item( $items ) {

--- a/wp-auction-manager.php
+++ b/wp-auction-manager.php
@@ -67,6 +67,7 @@ function wpam_load_textdomain() {
     load_plugin_textdomain( 'wpam', false, basename( dirname( __FILE__ ) ) . '/languages' );
 }
 add_action( 'init', 'wpam_load_textdomain' );
+add_action( 'init', [ '\\WPAM\\Includes\\WPAM_Install', 'register_endpoints' ] );
 
 /**
  * Show admin notice when WooCommerce is missing.


### PR DESCRIPTION
## Summary
- centralize watchlist, my-bids, and auctions-won endpoint registration
- hook rewrite endpoint registration to `init`
- flush rewrite rules during activation after scheduling endpoint registration

## Testing
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_688fd8d09d0c833397742f3641998a96