### PR TITLE
feat: expose bidding options for standard auctions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ When editing an auction product you can configure additional options in the **Au
 - **Auto Relist** – automatically relist when no winning bid exists. Configure a relist limit, delay before relisting and optional price adjustments.
 - **Max Bids Per User** – limit how many bids each user can place.
 - **Auction Fee** – extra fee added to the winning bid.
-- **Proxy Bidding** – automatically outbid others up to a maximum amount.
-- **Silent Bidding** – hides all bids until the auction ends.
+- **Proxy Bidding** – automatically outbid others up to a maximum amount. Available for standard auctions when enabled in settings; not supported for reverse auctions.
+- **Silent Bidding** – hides all bids until the auction ends. Sealed auctions are always silent, and standard auctions can enable this when allowed in settings; reverse auctions do not support it.
 
 The auction panel includes a contextual help column. Hover or focus on any field to see a description in the right-hand panel, replacing WooCommerce's default tooltips.
 

--- a/assets/admin/js/auction-type-toggle.js
+++ b/assets/admin/js/auction-type-toggle.js
@@ -4,23 +4,23 @@ jQuery(function($){
         var reserve = $('._auction_reserve_field');
         var increment = $('._auction_increment_field');
         var variableInc = $('._auction_variable_increment_field, .show_if_variable_increment');
-        var sealedOpts = $('._auction_proxy_bidding_field, ._auction_silent_bidding_field');
+        var biddingOpts = $('._auction_proxy_bidding_field, ._auction_silent_bidding_field');
 
         if(type === 'sealed'){
             reserve.hide();
             increment.hide();
             variableInc.hide();
-            sealedOpts.show();
+            biddingOpts.show();
         } else if(type === 'reverse'){
             reserve.show();
             increment.show();
             variableInc.show();
-            sealedOpts.hide();
+            biddingOpts.hide();
         } else { // standard
             reserve.hide();
             increment.show();
             variableInc.show();
-            sealedOpts.hide();
+            biddingOpts.show();
         }
     }
 


### PR DESCRIPTION
## Summary
- show per-auction bidding options for standard and sealed types, hiding only for reverse
- document which auction types support proxy and silent bidding

## Testing
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_68909b7a165883339a7d7cc280170d27