### PR TITLE
feat: include bid thresholds in rejection messages

### DIFF
--- a/includes/bidding/ProxyStrategy.php
+++ b/includes/bidding/ProxyStrategy.php
@@ -17,7 +17,14 @@ class ProxyStrategy implements BidStrategyInterface {
         $increment = WPAM_Auction::get_bid_increment( $auction_id, $highest );
 
         if ( $max_bid < $highest + $increment ) {
-            wp_send_json_error( [ 'message' => __( 'Bid too low', 'wpam' ) ] );
+            $min_bid_allowed = $highest + $increment;
+            $formatted       = function_exists( 'wc_format_decimal' ) ? wc_format_decimal( $min_bid_allowed ) : $min_bid_allowed;
+            wp_send_json_error(
+                [
+                    'message' => sprintf( __( 'Bid too low. Minimum bid is %s', 'wpam' ), $formatted ),
+                    'min_bid' => (float) $min_bid_allowed,
+                ]
+            );
         }
 
         $place_bid = ( $highest > 0 ) ? min( $max_bid, $highest + $increment ) : $max_bid;

--- a/includes/bidding/StandardStrategy.php
+++ b/includes/bidding/StandardStrategy.php
@@ -18,11 +18,25 @@ class StandardStrategy implements BidStrategyInterface {
 
         if ( $reverse ) {
             if ( $highest_row && $bid > $highest - $increment ) {
-                wp_send_json_error( [ 'message' => __( 'Bid too high', 'wpam' ) ] );
+                $max_bid_allowed = $highest - $increment;
+                $formatted       = function_exists( 'wc_format_decimal' ) ? wc_format_decimal( $max_bid_allowed ) : $max_bid_allowed;
+                wp_send_json_error(
+                    [
+                        'message' => sprintf( __( 'Bid too high. Maximum bid is %s', 'wpam' ), $formatted ),
+                        'max_bid' => (float) $max_bid_allowed,
+                    ]
+                );
             }
         } else {
             if ( $bid < $highest + $increment ) {
-                wp_send_json_error( [ 'message' => __( 'Bid too low', 'wpam' ) ] );
+                $min_bid_allowed = $highest + $increment;
+                $formatted       = function_exists( 'wc_format_decimal' ) ? wc_format_decimal( $min_bid_allowed ) : $min_bid_allowed;
+                wp_send_json_error(
+                    [
+                        'message' => sprintf( __( 'Bid too low. Minimum bid is %s', 'wpam' ), $formatted ),
+                        'min_bid' => (float) $min_bid_allowed,
+                    ]
+                );
             }
         }
 

--- a/languages/wp-auction-manager.pot
+++ b/languages/wp-auction-manager.pot
@@ -159,3 +159,11 @@ msgstr ""
 #: includes/class-wpam-auction.php
 msgid "Use different minimum increments based on current bid."
 msgstr ""
+
+#: includes/bidding/StandardStrategy.php:25
+msgid "Bid too high. Maximum bid is %s"
+msgstr ""
+
+#: includes/bidding/StandardStrategy.php:36 includes/bidding/ProxyStrategy.php:24
+msgid "Bid too low. Minimum bid is %s"
+msgstr ""

--- a/public/js/ajax-bid.js
+++ b/public/js/ajax-bid.js
@@ -195,6 +195,11 @@ jQuery(function ($) {
           }
         } else {
           toastr.error(res.data.message);
+          if (res.data && typeof res.data.min_bid !== 'undefined') {
+            bidInput.val(res.data.min_bid);
+          } else if (res.data && typeof res.data.max_bid !== 'undefined') {
+            bidInput.val(res.data.max_bid);
+          }
         }
       }
     );

--- a/tests/test-auction-types.php
+++ b/tests/test-auction-types.php
@@ -33,7 +33,8 @@ class Test_WPAM_Auction_Types extends WP_Ajax_UnitTestCase {
         try { $this->_handleAjax( 'wpam_place_bid' ); } catch ( WPAjaxDieContinueException $e ) {
             $resp = json_decode( $this->_last_response, true );
             $this->assertFalse( $resp['success'] );
-            $this->assertSame( 'Bid too high', $resp['data']['message'] );
+            $this->assertSame( 'Bid too high. Maximum bid is 99', $resp['data']['message'] );
+            $this->assertSame( 99.0, $resp['data']['max_bid'] );
         }
 
         $_POST = [

--- a/tests/test-bid-strategies.php
+++ b/tests/test-bid-strategies.php
@@ -38,7 +38,8 @@ class Test_WPAM_Bid_Strategies extends WP_Ajax_UnitTestCase {
         } catch ( WPAjaxDieContinueException $e ) {
             $response = json_decode( $this->_last_response, true );
             $this->assertFalse( $response['success'] );
-            $this->assertSame( 'Bid too low', $response['data']['message'] );
+            $this->assertSame( 'Bid too low. Minimum bid is 11', $response['data']['message'] );
+            $this->assertSame( 11.0, $response['data']['min_bid'] );
             return;
         }
         $this->fail( 'Expected AJAX die.' );

--- a/tests/test-variable-increment.php
+++ b/tests/test-variable-increment.php
@@ -30,7 +30,8 @@ class Test_WPAM_Variable_Increment extends WP_Ajax_UnitTestCase {
         } catch ( WPAjaxDieContinueException $e ) {
             $response = json_decode( $this->_last_response, true );
             $this->assertFalse( $response['success'] );
-            $this->assertSame( 'Bid too low', $response['data']['message'] );
+            $this->assertSame( 'Bid too low. Minimum bid is 2', $response['data']['message'] );
+            $this->assertSame( 2.0, $response['data']['min_bid'] );
             return;
         }
         $this->fail( 'Expected low bid rejection' );
@@ -61,7 +62,8 @@ class Test_WPAM_Variable_Increment extends WP_Ajax_UnitTestCase {
         } catch ( WPAjaxDieContinueException $e ) {
             $response = json_decode( $this->_last_response, true );
             $this->assertFalse( $response['success'] );
-            $this->assertSame( 'Bid too low', $response['data']['message'] );
+            $this->assertSame( 'Bid too low. Minimum bid is 65', $response['data']['message'] );
+            $this->assertSame( 65.0, $response['data']['min_bid'] );
             return;
         }
         $this->fail( 'Expected low bid rejection after threshold' );


### PR DESCRIPTION
## Summary
- provide minimum or maximum bid info when rejecting bids
- surface threshold details on client side and update translations
- update tests for new validation messages

## Testing
- `vendor/bin/phpcs includes/bidding/StandardStrategy.php includes/bidding/ProxyStrategy.php tests/test-bid-strategies.php tests/test-variable-increment.php tests/test-auction-types.php`
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_68909d97a86c8333b61c3d75868463ce