### PR TITLE
Add transaction handling to proxy bidding

### DIFF
--- a/includes/bidding/ProxyStrategy.php
+++ b/includes/bidding/ProxyStrategy.php
@@ -9,66 +9,92 @@ class ProxyStrategy implements BidStrategyInterface {
         global $wpdb;
         $table = $wpdb->prefix . 'wc_auction_bids';
 
-        $order       = 'DESC';
-        $highest_row = $wpdb->get_row( $wpdb->prepare( "SELECT user_id, bid_amount FROM $table WHERE auction_id = %d ORDER BY bid_amount {$order}, id DESC LIMIT 1", $auction_id ), ARRAY_A );
-        $highest     = $highest_row ? ( function_exists( 'wc_format_decimal' ) ? (float) wc_format_decimal( $highest_row['bid_amount'] ) : (float) $highest_row['bid_amount'] ) : 0;
-        $highest_user = $highest_row ? intval( $highest_row['user_id'] ) : 0;
+        $max_retries = 3;
+        for ( $attempt = 0; $attempt < $max_retries; $attempt++ ) {
+            $wpdb->query( 'START TRANSACTION' );
 
-        $increment = WPAM_Auction::get_bid_increment( $auction_id, $highest );
+            try {
+                $order       = 'DESC';
+                $highest_row = $wpdb->get_row( $wpdb->prepare( "SELECT user_id, bid_amount FROM $table WHERE auction_id = %d ORDER BY bid_amount {$order}, id DESC LIMIT 1 FOR UPDATE", $auction_id ), ARRAY_A );
+                $highest     = $highest_row ? ( function_exists( 'wc_format_decimal' ) ? (float) wc_format_decimal( $highest_row['bid_amount'] ) : (float) $highest_row['bid_amount'] ) : 0;
+                $highest_user = $highest_row ? intval( $highest_row['user_id'] ) : 0;
 
-        if ( $max_bid < $highest + $increment ) {
-            $min_bid_allowed = $highest + $increment;
-            $formatted       = function_exists( 'wc_format_decimal' ) ? wc_format_decimal( $min_bid_allowed ) : $min_bid_allowed;
-            wp_send_json_error(
-                [
-                    'message' => sprintf( __( 'Bid too low. Minimum bid is %s', 'wpam' ), $formatted ),
-                    'min_bid' => (float) $min_bid_allowed,
-                ]
-            );
-        }
+                $increment = WPAM_Auction::get_bid_increment( $auction_id, $highest );
 
-        $place_bid = ( $highest > 0 ) ? min( $max_bid, $highest + $increment ) : $max_bid;
-        $wpdb->insert(
-            $table,
-            [
-                'auction_id' => $auction_id,
-                'user_id'    => $user_id,
-                'bid_amount' => $place_bid,
-                'bid_time'   => wp_date( 'Y-m-d H:i:s', null, new \DateTimeZone( 'UTC' ) ),
-            ],
-            [ '%d', '%d', '%f', '%s' ]
-        );
-        WPAM_Bid::log_bid( $wpdb->insert_id, $user_id );
-        do_action( 'wpam_bid_placed', $auction_id, $user_id, $place_bid );
-        update_user_meta( $user_id, 'wpam_proxy_max_' . $auction_id, $max_bid );
+                if ( $max_bid < $highest + $increment ) {
+                    $wpdb->query( 'ROLLBACK' );
+                    $min_bid_allowed = $highest + $increment;
+                    $formatted       = function_exists( 'wc_format_decimal' ) ? wc_format_decimal( $min_bid_allowed ) : $min_bid_allowed;
+                    wp_send_json_error(
+                        [
+                            'message' => sprintf( __( 'Bid too low. Minimum bid is %s', 'wpam' ), $formatted ),
+                            'min_bid' => (float) $min_bid_allowed,
+                        ]
+                    );
+                }
 
-        $bid = $place_bid;
-
-        if ( $highest_user && $highest_user !== $user_id ) {
-            $prev_max = get_user_meta( $highest_user, 'wpam_proxy_max_' . $auction_id, true );
-            $prev_max = $prev_max ? ( function_exists( 'wc_format_decimal' ) ? (float) wc_format_decimal( $prev_max ) : (float) $prev_max ) : $highest;
-            if ( $prev_max > $place_bid ) {
-                $auto_bid = min( $prev_max, $place_bid + $increment );
-                $wpdb->insert(
+                $place_bid = ( $highest > 0 ) ? min( $max_bid, $highest + $increment ) : $max_bid;
+                $insert    = $wpdb->insert(
                     $table,
                     [
                         'auction_id' => $auction_id,
-                        'user_id'    => $highest_user,
-                        'bid_amount' => $auto_bid,
+                        'user_id'    => $user_id,
+                        'bid_amount' => $place_bid,
                         'bid_time'   => wp_date( 'Y-m-d H:i:s', null, new \DateTimeZone( 'UTC' ) ),
                     ],
                     [ '%d', '%d', '%f', '%s' ]
                 );
-                WPAM_Bid::log_bid( $wpdb->insert_id, $highest_user );
-                do_action( 'wpam_bid_placed', $auction_id, $highest_user, $auto_bid );
-                $bid = $auto_bid;
-            } else {
-                $highest_user = $user_id;
-            }
-        } else {
-            $highest_user = $user_id;
-        }
 
-        return [ 'bid' => $bid ];
+                if ( false === $insert ) {
+                    throw new \Exception( 'insert failed' );
+                }
+
+                WPAM_Bid::log_bid( $wpdb->insert_id, $user_id );
+                do_action( 'wpam_bid_placed', $auction_id, $user_id, $place_bid );
+                update_user_meta( $user_id, 'wpam_proxy_max_' . $auction_id, $max_bid );
+
+                $bid = $place_bid;
+
+                if ( $highest_user && $highest_user !== $user_id ) {
+                    $prev_max = get_user_meta( $highest_user, 'wpam_proxy_max_' . $auction_id, true );
+                    $prev_max = $prev_max ? ( function_exists( 'wc_format_decimal' ) ? (float) wc_format_decimal( $prev_max ) : (float) $prev_max ) : $highest;
+                    if ( $prev_max > $place_bid ) {
+                        $auto_bid = min( $prev_max, $place_bid + $increment );
+                        $auto     = $wpdb->insert(
+                            $table,
+                            [
+                                'auction_id' => $auction_id,
+                                'user_id'    => $highest_user,
+                                'bid_amount' => $auto_bid,
+                                'bid_time'   => wp_date( 'Y-m-d H:i:s', null, new \DateTimeZone( 'UTC' ) ),
+                            ],
+                            [ '%d', '%d', '%f', '%s' ]
+                        );
+
+                        if ( false === $auto ) {
+                            throw new \Exception( 'auto-bid insert failed' );
+                        }
+
+                        WPAM_Bid::log_bid( $wpdb->insert_id, $highest_user );
+                        do_action( 'wpam_bid_placed', $auction_id, $highest_user, $auto_bid );
+                        $bid = $auto_bid;
+                    } else {
+                        $highest_user = $user_id;
+                    }
+                } else {
+                    $highest_user = $user_id;
+                }
+
+                $wpdb->query( 'COMMIT' );
+                return [ 'bid' => $bid ];
+            } catch ( \Throwable $e ) {
+                $wpdb->query( 'ROLLBACK' );
+                if ( $attempt === $max_retries - 1 ) {
+                    wp_send_json_error( [ 'message' => __( 'Could not place bid. Please try again.', 'wpam' ) ] );
+                }
+
+                usleep( 50000 ); // brief pause before retrying
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- ensure proxy bids run inside a transaction with `SELECT ... FOR UPDATE`
- add rollback-and-retry logic when bid insertions fail

## Testing
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Error establishing a database connection)*
- `bash bin/install-wp-tests.sh wordpress_test root '' localhost latest` *(fails: svn is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6890a62c2d848333bdd7db306721c6c5