### PR TITLE
chore: restore Tailwind layer directives

### DIFF
--- a/clients/src/index.css
+++ b/clients/src/index.css
@@ -1,13 +1,8 @@
-/* 
-@import "tw-animate-css";
-
 @custom-variant dark (&:is(.dark *));
 
 @tailwind base;
 @tailwind components;
-@tailwind utilities; */
-
-@import "tailwindcss";
+@tailwind utilities;
 
 @theme inline {
 	--radius-sm: calc(var(--radius) - 4px);


### PR DESCRIPTION
## Summary
- restore Tailwind base/component/utility layers in client CSS so shadcn components inherit styles

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890c582adbc83338e5c2477e65f5bc0