### PR TITLE
feat: add WordPress design tokens and styles

### DIFF
--- a/clients/src/components/layout/AdminLayout.jsx
+++ b/clients/src/components/layout/AdminLayout.jsx
@@ -14,9 +14,9 @@ export default function AdminLayout({ children }) {
     highlightSubmenu(location.pathname);
   }, [location.pathname]);
   return (
-    <div className="flex min-h-screen flex-col">
-      <header className="sticky top-0 z-10 border-b bg-background">
-        <nav className="mx-auto flex max-w-6xl gap-4 p-4">
+    <div className="flex min-h-screen flex-col bg-wp-gray-100 font-sans text-wp-gray-900">
+      <header className="sticky top-0 z-10 border-b border-wp-gray-300 bg-wp-gray-100">
+        <nav className="mx-auto flex max-w-6xl gap-wp-2 p-wp-2">
           {navItems.map((item) => (
             <Button
               key={item.path}
@@ -28,7 +28,7 @@ export default function AdminLayout({ children }) {
           ))}
         </nav>
       </header>
-      <main className="flex-1 overflow-y-auto p-4">{children}</main>
+      <main className="flex-1 overflow-y-auto p-wp-2">{children}</main>
     </div>
   );
 }

--- a/clients/src/components/ui/button.tsx
+++ b/clients/src/components/ui/button.tsx
@@ -5,27 +5,27 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-wp-1 whitespace-nowrap rounded-sm font-sans text-wp-base font-medium transition-colors disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-wp-blue",
   {
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+          "bg-wp-blue text-wp-white shadow-sm hover:bg-wp-blue-dark",
         destructive:
-          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "bg-wp-red text-wp-white shadow-sm hover:bg-wp-red/90 focus-visible:ring-wp-red/20",
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+          "border border-wp-gray-300 bg-wp-white text-wp-gray-900 shadow-sm hover:bg-wp-gray-100",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+          "bg-wp-gray-100 text-wp-gray-900 shadow-sm hover:bg-wp-gray-300",
         ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
+          "text-wp-gray-900 hover:bg-wp-gray-100",
+        link: "text-wp-blue underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
+        default: "h-[40px] px-wp-2 py-wp-1 has-[>svg]:px-wp-1.5",
+        sm: "h-[32px] rounded-sm gap-wp-0.5 px-wp-1.5 has-[>svg]:px-wp-1",
+        lg: "h-[48px] rounded-sm px-wp-3 has-[>svg]:px-wp-2",
+        icon: "size-[40px]",
       },
     },
     defaultVariants: {

--- a/clients/src/components/ui/card.tsx
+++ b/clients/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "flex flex-col gap-wp-3 rounded-md border border-wp-gray-300 bg-wp-white py-wp-3 text-wp-gray-900 shadow-sm",
         className
       )}
       {...props}
@@ -20,7 +20,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-header"
       className={cn(
-        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-wp-1.5 px-wp-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-wp-3",
         className
       )}
       {...props}
@@ -42,7 +42,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn("text-wp-gray-700 text-wp-sm", className)}
       {...props}
     />
   )
@@ -65,7 +65,7 @@ function CardContent({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-content"
-      className={cn("px-6", className)}
+      className={cn("px-wp-3", className)}
       {...props}
     />
   )
@@ -75,7 +75,7 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-footer"
-      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      className={cn("flex items-center px-wp-3 [.border-t]:pt-wp-3", className)}
       {...props}
     />
   )

--- a/clients/src/components/ui/input.tsx
+++ b/clients/src/components/ui/input.tsx
@@ -7,7 +7,7 @@ const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLI
       <input
         type={type}
         className={cn(
-          'flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          'flex h-[40px] w-full rounded-sm border border-wp-gray-300 bg-wp-white px-wp-2 py-wp-1 font-sans text-wp-base shadow-sm placeholder:text-wp-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-wp-blue focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
           className
         )}
         ref={ref}

--- a/clients/src/components/ui/select.tsx
+++ b/clients/src/components/ui/select.tsx
@@ -17,7 +17,7 @@ export function Select({ value, options, onChange, className }: SelectProps) {
   return (
     <select
       className={cn(
-        'h-9 w-full rounded-md border border-input bg-background px-2 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        'h-[40px] w-full rounded-sm border border-wp-gray-300 bg-wp-white px-wp-2 py-wp-1 font-sans text-wp-base shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-wp-blue focus-visible:ring-offset-2',
         className
       )}
       value={value}

--- a/clients/src/components/ui/toast.jsx
+++ b/clients/src/components/ui/toast.jsx
@@ -13,8 +13,8 @@ export default function Toast({ open, type = 'success', message, onOpenChange })
   return (
     <div
       className={cn(
-        'fixed bottom-4 right-4 rounded-md px-4 py-2 text-sm text-white shadow-lg',
-        type === 'error' ? 'bg-destructive' : 'bg-primary'
+        'fixed bottom-wp-4 right-wp-4 rounded-sm px-wp-3 py-wp-1 text-wp-base text-wp-white shadow-lg',
+        type === 'error' ? 'bg-wp-red' : 'bg-wp-blue'
       )}
     >
       {message}

--- a/clients/src/components/ui/toggle.tsx
+++ b/clients/src/components/ui/toggle.tsx
@@ -15,15 +15,15 @@ export function Toggle({ checked, onCheckedChange, className }: ToggleProps) {
       aria-checked={checked}
       onClick={() => onCheckedChange(!checked)}
       className={cn(
-        'relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border border-input transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-        checked ? 'bg-primary' : 'bg-input',
+        'relative inline-flex h-[24px] w-[44px] shrink-0 cursor-pointer items-center rounded-full border border-wp-gray-300 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-wp-blue',
+        checked ? 'bg-wp-blue' : 'bg-wp-gray-300',
         className
       )}
     >
       <span
         className={cn(
-          'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-background shadow transition-transform',
-          checked ? 'translate-x-5' : 'translate-x-1'
+          'pointer-events-none inline-block h-[20px] w-[20px] transform rounded-full bg-wp-white shadow transition-transform',
+          checked ? 'translate-x-[20px]' : 'translate-x-[4px]'
         )}
       />
     </button>

--- a/clients/tailwind.config.js
+++ b/clients/tailwind.config.js
@@ -1,10 +1,65 @@
+import defaultTheme from "tailwindcss/defaultTheme";
+
 export default {
   content: [
     "./index.html",
     "./src/**/*.{js,jsx,ts,tsx}"
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        wp: {
+          blue: "#2271b1",
+          "blue-dark": "#135e96",
+          black: "#000",
+          white: "#fff",
+          red: "#cc1818",
+          yellow: "#f0b849",
+          green: "#4ab866",
+          gray: {
+            900: "#1e1e1e",
+            700: "#757575",
+            400: "#ccc",
+            300: "#ddd",
+            100: "#f0f0f0",
+          },
+        },
+      },
+      fontFamily: {
+        sans: [
+          "-apple-system",
+          "BlinkMacSystemFont",
+          "Segoe UI",
+          "Roboto",
+          "Oxygen-Sans",
+          "Ubuntu",
+          "Cantarell",
+          "Helvetica Neue",
+          "sans-serif",
+          ...defaultTheme.fontFamily.sans,
+        ],
+      },
+      fontSize: {
+        "wp-xs": ["11px", "16px"],
+        "wp-sm": ["12px", "20px"],
+        "wp-base": ["13px", "24px"],
+        "wp-lg": ["15px", "28px"],
+        "wp-xl": ["20px", "32px"],
+        "wp-2xl": ["32px", "40px"],
+      },
+      spacing: {
+        "wp-0.5": "4px",
+        "wp-1": "8px",
+        "wp-1.5": "12px",
+        "wp-2": "16px",
+        "wp-3": "24px",
+        "wp-4": "32px",
+        "wp-5": "40px",
+        "wp-6": "48px",
+        "wp-7": "56px",
+        "wp-8": "64px",
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- extend Tailwind with WordPress color palette, typography and spacing tokens
- apply Gutenberg-like WordPress styling across UI and layout components

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890dc9534848333a3876af693cb5973