### PR TITLE
Send boolean values from settings toggles

### DIFF
--- a/clients/src/pages/Settings.jsx
+++ b/clients/src/pages/Settings.jsx
@@ -220,7 +220,7 @@ export default function Settings() {
                 <label className="capitalize">{key.replace(/_/g, ' ')}</label>
                 <Toggle
                   checked={boolVal}
-                  onCheckedChange={(v) => updateField(key, v ? 1 : 0)}
+                  onCheckedChange={(v) => updateField(key, v)}
                 />
                 {errors[key] && (
                   <p className="text-destructive text-sm">{errors[key]}</p>

--- a/tests/test-settings-endpoint.php
+++ b/tests/test-settings-endpoint.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Test settings endpoint handles boolean values.
+ */
+class Settings_Endpoint_Test extends WP_UnitTestCase {
+    public function test_boolean_settings_saved_and_returned() {
+        do_action( 'rest_api_init' );
+        $admin_id = self::factory()->user->create( ['role' => 'administrator'] );
+        wp_set_current_user( $admin_id );
+
+        $request = new WP_REST_Request( 'POST', '/wpam/v1/settings' );
+        $request->set_header( 'Content-Type', 'application/json' );
+        $request->set_body( wp_json_encode( [
+            'wpam_enable_toasts' => true,
+            'wpam_enable_twilio' => false,
+        ] ) );
+
+        $response = rest_get_server()->dispatch( $request );
+        $this->assertSame( 200, $response->get_status() );
+
+        $data = $response->get_data();
+        $this->assertTrue( $data['wpam_enable_toasts'] );
+        $this->assertFalse( $data['wpam_enable_twilio'] );
+
+        $this->assertTrue( (bool) get_option( 'wpam_enable_toasts' ) );
+        $this->assertFalse( (bool) get_option( 'wpam_enable_twilio' ) );
+    }
+}


### PR DESCRIPTION
## Summary
- Send raw boolean values from settings toggles so the backend receives true/false
- Add PHPUnit coverage to ensure settings endpoint stores booleans correctly

## Testing
- `npm run lint`
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Undefined array key "HTTP_HOST"; Cannot modify header information)*

------
https://chatgpt.com/codex/tasks/task_e_6890de52f990833394fce7f62bd2ae9a