### PR TITLE
Handle server validation errors in settings

### DIFF
--- a/clients/src/pages/Settings.jsx
+++ b/clients/src/pages/Settings.jsx
@@ -155,11 +155,18 @@ export default function Settings() {
         setToast({ open: true, type: 'success', message: 'Settings saved.' });
         setSaving(false);
       })
-      .catch(() => {
+      .catch((error) => {
+        const params = error.response?.data?.params;
+        if (params) {
+          setErrors((prev) => ({ ...prev, ...params }));
+        }
+        const summary =
+          error.response?.data?.message ||
+          'Failed to save settings. Please review the highlighted fields.';
         setToast({
           open: true,
           type: 'error',
-          message: 'Failed to save settings.',
+          message: summary,
         });
         setSaving(false);
       });


### PR DESCRIPTION
## Summary
- merge server validation messages into `errors` state in settings page
- show a toast summary message when saving fails

## Testing
- `npm test` *(fails: Missing script "test")*
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_6890e2e38c2883339905c9bbe70d6ce4