### PR TITLE
Update get_highest_bid to include bidder statuses

### DIFF
--- a/includes/class-wpam-bid.php
+++ b/includes/class-wpam-bid.php
@@ -324,6 +324,9 @@ class WPAM_Bid {
 			}
 		}
 
+		$statuses = self::calculate_statuses( $auction_id, $highest, $lead_user, $reverse );
+		$user_id  = get_current_user_id();
+
 		$ending_reason = '';
 		if ( WPAM_Auction_State::ENDED === $state ) {
 			$ending_reason = get_post_meta( $auction_id, '_auction_ending_reason', true );
@@ -335,6 +338,8 @@ class WPAM_Bid {
 			'start_ts'    => $start_ts,
 			'end_ts'      => $end_ts,
 			'state'       => $state,
+			'status'      => isset( $statuses[ $user_id ] ) ? $statuses[ $user_id ] : '',
+			'statuses'    => $statuses,
 		);
 		if ( $ending_reason ) {
 			$response['ending_reason'] = $ending_reason;


### PR DESCRIPTION
## Summary
- extend `get_highest_bid` to compute bidder statuses
- include bidder status details in the AJAX response for highest bid queries

## Testing
- `vendor/bin/phpunit --bootstrap=tests/bootstrap.php tests` *(fails: Error establishing a database connection)*
- `bash bin/install-wp-tests.sh wordpress_test root '' localhost latest` *(fails: mysql: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68937ef1ebb0833398a96c3cd64d1f8a