### PR TITLE
Improve auction status event handling

### DIFF
--- a/public/js/ajax-bid.js
+++ b/public/js/ajax-bid.js
@@ -383,9 +383,50 @@ jQuery(function ($) {
         }
       });
       channel.bind('auction_status', function (data) {
-        if (!data || !data.status) return;
-        if (data.status === 'ended') {
-          showToast(i18n.auction_ended || 'Auction ended', 'info');
+        if (!data || !data.status || !data.auction_id) return;
+
+        let status = data.status;
+        let toast = '';
+        let type = 'info';
+
+        switch (status) {
+          case 'started':
+          case 'resumed':
+            toast = i18n.auction_started || 'Auction started';
+            status = 'live';
+            break;
+          case 'suspended':
+            toast = i18n.auction_suspended || 'Auction suspended';
+            type = 'warning';
+            break;
+          case 'canceled':
+            toast = i18n.auction_canceled || 'Auction canceled';
+            type = 'warning';
+            break;
+          case 'failed':
+            toast = i18n.auction_failed || 'Auction failed';
+            break;
+          case 'completed':
+            toast = i18n.auction_completed || 'Auction completed';
+            break;
+          default:
+            return;
+        }
+
+        updateCountdown(data.auction_id, data.start_ts, data.end_ts, status);
+
+        const container =
+          $('[data-auction-id="' + data.auction_id + '"]').closest(
+            '.auction-single, .wpam-auction-block'
+          );
+        if (container.length) {
+          container.attr('data-status', status);
+          if (data.start_ts) container.attr('data-start', data.start_ts);
+          if (data.end_ts) container.attr('data-end', data.end_ts);
+        }
+
+        if (toast) {
+          showToast(toast, type);
         }
       });
       const presence = pusher.subscribe('presence-auction-' + auctionId);


### PR DESCRIPTION
## Summary
- handle Pusher `auction_status` messages for start, suspension, cancellation, failure and completion
- dispatch `auction_status` on all lifecycle transitions in `WPAM_Auction`

## Testing
- `node --check public/js/ajax-bid.js`
- `vendor/bin/phpunit tests` *(no tests executed)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6893878827a0833392e296fb30bf0de6