### PR TITLE
Add configurable fallback bid polling

### DIFF
--- a/public/js/ajax-bid.js
+++ b/public/js/ajax-bid.js
@@ -462,6 +462,7 @@ jQuery(function ($) {
       });
     });
   } else {
-    setInterval(refreshBids, 5000);
+    const pollInterval = parseInt(wpam_ajax.poll_interval, 10) || 5000;
+    setInterval(refreshBids, pollInterval);
   }
 });


### PR DESCRIPTION
## Summary
- add configurable interval for bid polling when Pusher is disabled
- ensure polling still applies bid statuses to prevent stale max-bid notices

## Testing
- `npm test` (fails: missing script)
- `vendor/bin/phpunit` (displays usage information, no tests executed)


------
https://chatgpt.com/codex/tasks/task_e_68938a155678833396d1dd2ae4c02f43