### PR TITLE
Invoke auction end handler for ended listings

### DIFF
--- a/includes/class-wpam-auction.php
+++ b/includes/class-wpam-auction.php
@@ -950,8 +950,8 @@ class WPAM_Auction {
                         );
 
                         foreach ( $query->posts as $post ) {
+                                $this->handle_auction_end( $post->ID );
                                 update_post_meta( $post->ID, '_auction_ended', 1 );
-                                update_post_meta( $post->ID, '_auction_state', WPAM_Auction_State::ENDED );
                         }
 
                         wp_reset_postdata();


### PR DESCRIPTION
## Summary
- call `handle_auction_end()` for each expired auction instead of manually setting state
- maintain `_auction_ended` meta flag after processing

## Testing
- `./vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Error establishing a database connection)*
- `./vendor/bin/phpcs includes/class-wpam-auction.php` *(1722 errors, 851 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689484c170988333953df92b036c765e