### PR TITLE
Guard bidding controls after auction ends

### DIFF
--- a/includes/class-wpam-html.php
+++ b/includes/class-wpam-html.php
@@ -67,32 +67,40 @@ class WPAM_HTML {
     echo '<p>' . esc_html__( 'Participants:', 'wpam' ) . ' <span class="wpam-participant-count" data-auction-id="' . esc_attr( $auction_id ) . '">0</span></p>';
 
     $winner_id = (int) get_post_meta( $auction_id, '_auction_winner', true );
-    if ( $atts['showWinner'] && 'completed' === $status && $winner_id ) {
-      $current_user_id = get_current_user_id();
-      if ( $current_user_id === $winner_id ) {
-        echo '<p class="wpam-auction-winner">' . esc_html__( 'You won this auction', 'wpam' ) . '</p>';
-      } else {
-        $user        = get_userdata( $winner_id );
-        $name        = $user ? $user->display_name : '';
-        $anon_name   = $name ? substr( $name, 0, 1 ) . str_repeat( '*', max( strlen( $name ) - 1, 0 ) ) : __( 'Unknown', 'wpam' );
-        $winner_text = sprintf( __( 'Winner: %s', 'wpam' ), $anon_name );
-        echo '<p class="wpam-auction-winner">' . esc_html( $winner_text ) . '</p>';
+    if ( $atts['showWinner'] ) {
+      if ( 'completed' === $status && $winner_id ) {
+        $current_user_id = get_current_user_id();
+        if ( $current_user_id === $winner_id ) {
+          echo '<p class="wpam-auction-winner">' . esc_html__( 'You won this auction', 'wpam' ) . '</p>';
+        } else {
+          $user        = get_userdata( $winner_id );
+          $name        = $user ? $user->display_name : '';
+          $anon_name   = $name ? substr( $name, 0, 1 ) . str_repeat( '*', max( strlen( $name ) - 1, 0 ) ) : __( 'Unknown', 'wpam' );
+          $winner_text = sprintf( __( 'Winner: %s', 'wpam' ), $anon_name );
+          echo '<p class="wpam-auction-winner">' . esc_html( $winner_text ) . '</p>';
+        }
+      } elseif ( 'failed' === $status ) {
+        echo '<p class="wpam-auction-winner">' . esc_html__( 'Auction ended without a winner', 'wpam' ) . '</p>';
+      } elseif ( 'ended' === $status ) {
+        echo '<p class="wpam-auction-winner">' . esc_html__( 'Processing results...', 'wpam' ) . '</p>';
       }
     }
 
-    if ( $atts['showBidForm'] ) {
-      echo '<form class="wpam-bid-form">';
-      echo '<input type="number" step="0.01" class="wpam-bid-input" />';
-      wp_nonce_field( 'wpam_place_bid', 'wpam_bid_nonce', false );
-      echo '<button class="button wpam-bid-button" data-auction-id="' . esc_attr( $auction_id ) . '">' .
-           esc_html__( 'Place Bid', 'wpam' ) . '</button>';
-      echo '</form>';
-    }
+    if ( 'live' === $status ) {
+      if ( $atts['showBidForm'] ) {
+        echo '<form class="wpam-bid-form">';
+        echo '<input type="number" step="0.01" class="wpam-bid-input" />';
+        wp_nonce_field( 'wpam_place_bid', 'wpam_bid_nonce', false );
+        echo '<button class="button wpam-bid-button" data-auction-id="' . esc_attr( $auction_id ) . '">' .
+             esc_html__( 'Place Bid', 'wpam' ) . '</button>';
+        echo '</form>';
+      }
 
-    if ( $atts['showWatchlist'] ) {
-      wp_nonce_field( 'wpam_toggle_watchlist', 'wpam_watchlist_nonce', false );
-      echo '<button class="button wpam-watchlist-button" data-auction-id="' . esc_attr( $auction_id ) . '">' .
-           esc_html__( 'Toggle Watchlist', 'wpam' ) . '</button>';
+      if ( $atts['showWatchlist'] ) {
+        wp_nonce_field( 'wpam_toggle_watchlist', 'wpam_watchlist_nonce', false );
+        echo '<button class="button wpam-watchlist-button" data-auction-id="' . esc_attr( $auction_id ) . '">' .
+             esc_html__( 'Toggle Watchlist', 'wpam' ) . '</button>';
+      }
     }
 
     echo '</div>';


### PR DESCRIPTION
## Summary
- Hide bid form and watchlist when an auction isn't live
- Display messages for failed and processing states in winner section

## Testing
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_689488c89a808333a4dfde7178500c61