### PR TITLE
feat: add logs page with table

### DIFF
--- a/clients/.gitignore
+++ b/clients/.gitignore
@@ -1,5 +1,5 @@
 # Logs
-logs
+/logs
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/clients/src/pages/logs/index.jsx
+++ b/clients/src/pages/logs/index.jsx
@@ -1,0 +1,37 @@
+import { useEffect } from 'react'
+import { useSubmenu } from '@/context/submenu-context'
+import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table'
+
+export default function Logs() {
+  const { highlightSubmenu } = useSubmenu()
+
+  useEffect(() => {
+    highlightSubmenu('/logs')
+  }, [highlightSubmenu])
+
+  const logEntries = [
+    { id: 1, action: 'Sample action', date: '2024-01-01' },
+    { id: 2, action: 'Another action', date: '2024-01-02' },
+  ]
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>ID</TableHead>
+          <TableHead>Action</TableHead>
+          <TableHead>Date</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {logEntries.map((log) => (
+          <TableRow key={log.id}>
+            <TableCell>{log.id}</TableCell>
+            <TableCell>{log.action}</TableCell>
+            <TableCell>{log.date}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}


### PR DESCRIPTION
## Summary
- add logs page in clients with submenu highlight
- render Shadcn table showing sample log entries
- tweak client .gitignore to allow logs page tracking

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: react-refresh/only-export-components, no-unused-vars, no-undef)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68966805c98c8333b6ce95400097c5ef