### PR TITLE
feat(clients): add table listings with pagination

### DIFF
--- a/clients/src/pages/auctions/index.jsx
+++ b/clients/src/pages/auctions/index.jsx
@@ -1,12 +1,101 @@
-import { useEffect } from 'react'
-import { useSubmenu } from '@/context/submenu-context'
+import { useEffect, useState } from 'react';
+import { useSubmenu } from '@/context/submenu-context';
+import { Header } from '@/components/layout/header';
+import { Main } from '@/components/layout/main';
+import { Search } from '@/components/search';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '@/components/ui/table';
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationPrevious,
+  PaginationNext,
+} from '@/components/ui/pagination';
 
 export default function Auctions() {
-  const { highlightSubmenu } = useSubmenu()
+  const { highlightSubmenu } = useSubmenu();
+  const [auctions, setAuctions] = useState([]);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
 
   useEffect(() => {
-    highlightSubmenu('/all-auctions')
-  }, [highlightSubmenu])
+    highlightSubmenu('/all-auctions');
+  }, [highlightSubmenu]);
 
-  return <div>Auctions page content</div>
+  useEffect(() => {
+    const controller = new AbortController();
+
+    fetch(`/wp-json/wpam/v1/auctions?page=${page}`, { signal: controller.signal })
+      .then((res) => res.json())
+      .then((data) => {
+        setAuctions(data.items || data || []);
+        setTotalPages(data.totalPages || 1);
+      })
+      .catch(() => {});
+
+    return () => controller.abort();
+  }, [page]);
+
+  return (
+    <>
+      <Header>
+        <Search placeholder="Search auctions" />
+      </Header>
+      <Main fixed>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>ID</TableHead>
+              <TableHead>Title</TableHead>
+              <TableHead>Status</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {auctions.map((auction) => (
+              <TableRow key={auction.id}>
+                <TableCell>{auction.id}</TableCell>
+                <TableCell>{auction.title || auction.name}</TableCell>
+                <TableCell>{auction.status}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+        <Pagination className="mt-4">
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationPrevious
+                href="#"
+                onClick={() => setPage((p) => Math.max(p - 1, 1))}
+              />
+            </PaginationItem>
+            {Array.from({ length: totalPages }, (_, i) => (
+              <PaginationItem key={i}>
+                <PaginationLink
+                  href="#"
+                  isActive={page === i + 1}
+                  onClick={() => setPage(i + 1)}
+                >
+                  {i + 1}
+                </PaginationLink>
+              </PaginationItem>
+            ))}
+            <PaginationItem>
+              <PaginationNext
+                href="#"
+                onClick={() => setPage((p) => Math.min(p + 1, totalPages))}
+              />
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
+      </Main>
+    </>
+  );
 }

--- a/clients/src/pages/bids/index.jsx
+++ b/clients/src/pages/bids/index.jsx
@@ -1,12 +1,103 @@
-import { useEffect } from 'react'
-import { useSubmenu } from '@/context/submenu-context'
+import { useEffect, useState } from 'react';
+import { useSubmenu } from '@/context/submenu-context';
+import { Header } from '@/components/layout/header';
+import { Main } from '@/components/layout/main';
+import { Search } from '@/components/search';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '@/components/ui/table';
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationPrevious,
+  PaginationNext,
+} from '@/components/ui/pagination';
 
 export default function Bids() {
-  const { highlightSubmenu } = useSubmenu()
+  const { highlightSubmenu } = useSubmenu();
+  const [bids, setBids] = useState([]);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
 
   useEffect(() => {
-    highlightSubmenu('/bids')
-  }, [highlightSubmenu])
+    highlightSubmenu('/bids');
+  }, [highlightSubmenu]);
 
-  return <div>Bids page content</div>
+  useEffect(() => {
+    const controller = new AbortController();
+
+    fetch(`/wp-json/wpam/v1/bids?page=${page}`, { signal: controller.signal })
+      .then((res) => res.json())
+      .then((data) => {
+        setBids(data.items || data || []);
+        setTotalPages(data.totalPages || 1);
+      })
+      .catch(() => {});
+
+    return () => controller.abort();
+  }, [page]);
+
+  return (
+    <>
+      <Header>
+        <Search placeholder="Search bids" />
+      </Header>
+      <Main fixed>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>ID</TableHead>
+              <TableHead>Auction</TableHead>
+              <TableHead>User</TableHead>
+              <TableHead>Amount</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {bids.map((bid) => (
+              <TableRow key={bid.id}>
+                <TableCell>{bid.id}</TableCell>
+                <TableCell>{bid.auction_id || bid.auction}</TableCell>
+                <TableCell>{bid.user_id || bid.user}</TableCell>
+                <TableCell>{bid.amount}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+        <Pagination className="mt-4">
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationPrevious
+                href="#"
+                onClick={() => setPage((p) => Math.max(p - 1, 1))}
+              />
+            </PaginationItem>
+            {Array.from({ length: totalPages }, (_, i) => (
+              <PaginationItem key={i}>
+                <PaginationLink
+                  href="#"
+                  isActive={page === i + 1}
+                  onClick={() => setPage(i + 1)}
+                >
+                  {i + 1}
+                </PaginationLink>
+              </PaginationItem>
+            ))}
+            <PaginationItem>
+              <PaginationNext
+                href="#"
+                onClick={() => setPage((p) => Math.min(p + 1, totalPages))}
+              />
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
+      </Main>
+    </>
+  );
 }

--- a/clients/src/pages/messages/index.jsx
+++ b/clients/src/pages/messages/index.jsx
@@ -1,12 +1,101 @@
-import { useEffect } from 'react'
-import { useSubmenu } from '@/context/submenu-context'
+import { useEffect, useState } from 'react';
+import { useSubmenu } from '@/context/submenu-context';
+import { Header } from '@/components/layout/header';
+import { Main } from '@/components/layout/main';
+import { Search } from '@/components/search';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '@/components/ui/table';
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationPrevious,
+  PaginationNext,
+} from '@/components/ui/pagination';
 
 export default function Messages() {
-  const { highlightSubmenu } = useSubmenu()
+  const { highlightSubmenu } = useSubmenu();
+  const [messages, setMessages] = useState([]);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
 
   useEffect(() => {
-    highlightSubmenu('/messages')
-  }, [highlightSubmenu])
+    highlightSubmenu('/messages');
+  }, [highlightSubmenu]);
 
-  return <div>Messages page content</div>
+  useEffect(() => {
+    const controller = new AbortController();
+
+    fetch(`/wp-json/wpam/v1/messages?page=${page}`, { signal: controller.signal })
+      .then((res) => res.json())
+      .then((data) => {
+        setMessages(data.items || data || []);
+        setTotalPages(data.totalPages || 1);
+      })
+      .catch(() => {});
+
+    return () => controller.abort();
+  }, [page]);
+
+  return (
+    <>
+      <Header>
+        <Search placeholder="Search messages" />
+      </Header>
+      <Main fixed>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>ID</TableHead>
+              <TableHead>From</TableHead>
+              <TableHead>Message</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {messages.map((message) => (
+              <TableRow key={message.id}>
+                <TableCell>{message.id}</TableCell>
+                <TableCell>{message.from}</TableCell>
+                <TableCell>{message.message || message.content}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+        <Pagination className="mt-4">
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationPrevious
+                href="#"
+                onClick={() => setPage((p) => Math.max(p - 1, 1))}
+              />
+            </PaginationItem>
+            {Array.from({ length: totalPages }, (_, i) => (
+              <PaginationItem key={i}>
+                <PaginationLink
+                  href="#"
+                  isActive={page === i + 1}
+                  onClick={() => setPage(i + 1)}
+                >
+                  {i + 1}
+                </PaginationLink>
+              </PaginationItem>
+            ))}
+            <PaginationItem>
+              <PaginationNext
+                href="#"
+                onClick={() => setPage((p) => Math.min(p + 1, totalPages))}
+              />
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
+      </Main>
+    </>
+  );
 }

--- a/clients/src/pages/users/index.jsx
+++ b/clients/src/pages/users/index.jsx
@@ -1,12 +1,101 @@
-import { useEffect } from 'react'
-import { useSubmenu } from '@/context/submenu-context'
+import { useEffect, useState } from 'react';
+import { useSubmenu } from '@/context/submenu-context';
+import { Header } from '@/components/layout/header';
+import { Main } from '@/components/layout/main';
+import { Search } from '@/components/search';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '@/components/ui/table';
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationPrevious,
+  PaginationNext,
+} from '@/components/ui/pagination';
 
 export default function Users() {
-  const { highlightSubmenu } = useSubmenu()
+  const { highlightSubmenu } = useSubmenu();
+  const [users, setUsers] = useState([]);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
 
   useEffect(() => {
-    highlightSubmenu('/users')
-  }, [highlightSubmenu])
+    highlightSubmenu('/users');
+  }, [highlightSubmenu]);
 
-  return <div>Users page content</div>
+  useEffect(() => {
+    const controller = new AbortController();
+
+    fetch(`/wp-json/wpam/v1/users?page=${page}`, { signal: controller.signal })
+      .then((res) => res.json())
+      .then((data) => {
+        setUsers(data.items || data || []);
+        setTotalPages(data.totalPages || 1);
+      })
+      .catch(() => {});
+
+    return () => controller.abort();
+  }, [page]);
+
+  return (
+    <>
+      <Header>
+        <Search placeholder="Search users" />
+      </Header>
+      <Main fixed>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>ID</TableHead>
+              <TableHead>Name</TableHead>
+              <TableHead>Email</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {users.map((user) => (
+              <TableRow key={user.id}>
+                <TableCell>{user.id}</TableCell>
+                <TableCell>{user.name}</TableCell>
+                <TableCell>{user.email}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+        <Pagination className="mt-4">
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationPrevious
+                href="#"
+                onClick={() => setPage((p) => Math.max(p - 1, 1))}
+              />
+            </PaginationItem>
+            {Array.from({ length: totalPages }, (_, i) => (
+              <PaginationItem key={i}>
+                <PaginationLink
+                  href="#"
+                  isActive={page === i + 1}
+                  onClick={() => setPage(i + 1)}
+                >
+                  {i + 1}
+                </PaginationLink>
+              </PaginationItem>
+            ))}
+            <PaginationItem>
+              <PaginationNext
+                href="#"
+                onClick={() => setPage((p) => Math.min(p + 1, totalPages))}
+              />
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
+      </Main>
+    </>
+  );
 }


### PR DESCRIPTION
## Summary
- replace placeholder content on auctions, bids, messages, and users pages with Shadcn tables
- add header, search, pagination, and REST fetching for listings

## Testing
- `npm run lint` *(fails: Fast refresh only works when a file only exports components, __dirname is not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68966a224e4c833383ba05464fe59c81