### PR TITLE
feat: centralize API calls with nonce-authenticated helper

### DIFF
--- a/clients/src/lib/api.js
+++ b/clients/src/lib/api.js
@@ -1,0 +1,9 @@
+import axios from 'axios';
+
+const api = axios.create({
+  headers: {
+    'X-WP-Nonce': window?.wpamData?.nonce ?? '',
+  },
+});
+
+export default api;

--- a/clients/src/pages/auctions/index.jsx
+++ b/clients/src/pages/auctions/index.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import api from '@/lib/api';
 import { useSubmenu } from '@/context/submenu-context';
 import { Header } from '@/components/layout/header';
 import { Main } from '@/components/layout/main';
@@ -33,9 +34,13 @@ export default function Auctions() {
   useEffect(() => {
     const controller = new AbortController();
 
-    fetch(`/wp-json/wpam/v1/auctions?page=${page}`, { signal: controller.signal })
-      .then((res) => res.json())
-      .then((data) => {
+    api
+      .get(window.wpamData.auctions_endpoint, {
+        params: { page },
+        signal: controller.signal,
+      })
+      .then((res) => {
+        const data = res.data;
         setAuctions(data.items || data || []);
         setTotalPages(data.totalPages || 1);
       })

--- a/clients/src/pages/bids/index.jsx
+++ b/clients/src/pages/bids/index.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import api from '@/lib/api';
 import { useSubmenu } from '@/context/submenu-context';
 import { Header } from '@/components/layout/header';
 import { Main } from '@/components/layout/main';
@@ -33,9 +34,13 @@ export default function Bids() {
   useEffect(() => {
     const controller = new AbortController();
 
-    fetch(`/wp-json/wpam/v1/bids?page=${page}`, { signal: controller.signal })
-      .then((res) => res.json())
-      .then((data) => {
+    api
+      .get(window.wpamData.bids_endpoint, {
+        params: { page },
+        signal: controller.signal,
+      })
+      .then((res) => {
+        const data = res.data;
         setBids(data.items || data || []);
         setTotalPages(data.totalPages || 1);
       })

--- a/clients/src/pages/messages/index.jsx
+++ b/clients/src/pages/messages/index.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import api from '@/lib/api';
 import { useSubmenu } from '@/context/submenu-context';
 import { Header } from '@/components/layout/header';
 import { Main } from '@/components/layout/main';
@@ -33,9 +34,13 @@ export default function Messages() {
   useEffect(() => {
     const controller = new AbortController();
 
-    fetch(`/wp-json/wpam/v1/messages?page=${page}`, { signal: controller.signal })
-      .then((res) => res.json())
-      .then((data) => {
+    api
+      .get(window.wpamData.messages_endpoint, {
+        params: { page },
+        signal: controller.signal,
+      })
+      .then((res) => {
+        const data = res.data;
         setMessages(data.items || data || []);
         setTotalPages(data.totalPages || 1);
       })

--- a/clients/src/pages/users/index.jsx
+++ b/clients/src/pages/users/index.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import api from '@/lib/api';
 import { useSubmenu } from '@/context/submenu-context';
 import { Header } from '@/components/layout/header';
 import { Main } from '@/components/layout/main';
@@ -33,9 +34,13 @@ export default function Users() {
   useEffect(() => {
     const controller = new AbortController();
 
-    fetch(`/wp-json/wpam/v1/users?page=${page}`, { signal: controller.signal })
-      .then((res) => res.json())
-      .then((data) => {
+    api
+      .get(window.wpamData.users_endpoint, {
+        params: { page },
+        signal: controller.signal,
+      })
+      .then((res) => {
+        const data = res.data;
         setUsers(data.items || data || []);
         setTotalPages(data.totalPages || 1);
       })


### PR DESCRIPTION
## Summary
- add axios helper that sets `X-WP-Nonce` header
- use new helper for auctions, bids, messages, and users pages

## Testing
- `npm run lint` *(fails: Fast refresh only works when a file only exports components; '__dirname' is not defined)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68967113a9788333af9fc2e77dfb20be