### PR TITLE
Use prefixer plugin for Tailwind styles

### DIFF
--- a/clients/tailwind.config.js
+++ b/clients/tailwind.config.js
@@ -1,12 +1,11 @@
-import defaultTheme from 'tailwindcss/defaultTheme';
 import forms from '@tailwindcss/forms';
 import typography from '@tailwindcss/typography';
 import aspectRatio from '@tailwindcss/aspect-ratio';
+import prefixer from '@tailwindcss/prefixer';
 
 export default {
-	// Avoid conflict with WP admin styles
-	prefix: 'tw-',
-	content: ['./**/*.php', './index.html', './src/**/*.{js,jsx,ts,tsx}'],
+        // Avoid conflict with WP admin styles
+        content: ['./**/*.php', './index.html', './src/**/*.{js,jsx,ts,tsx}'],
 	darkMode: true,
 	important: '#wpam-auctions-root',
 	// theme: {
@@ -65,7 +64,7 @@ export default {
 	// 		},
 	// 	},
 	// },
-	plugins: [forms, typography, aspectRatio],
+        plugins: [prefixer({ prefix: 'tw' }), forms, typography, aspectRatio],
 	safelist: [
 		{
 			pattern:


### PR DESCRIPTION
## Summary
- remove Tailwind's `prefix` option in clients config
- apply `@tailwindcss/prefixer` plugin with `tw` prefix

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: react-refresh/only-export-components and no-undef errors)


------
https://chatgpt.com/codex/tasks/task_e_6897403e6d6c83338ae87acc5ba47ae6