### PR TITLE
feat: update dark mode handling

### DIFF
--- a/clients/src/context/theme-context.jsx
+++ b/clients/src/context/theme-context.jsx
@@ -21,10 +21,13 @@ export function ThemeProvider({
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
 
     const applyTheme = (theme) => {
-      root.classList.remove('light', 'dark')
       const systemTheme = mediaQuery.matches ? 'dark' : 'light'
       const effectiveTheme = theme === 'system' ? systemTheme : theme
-      root.classList.add(effectiveTheme)
+      if (effectiveTheme === 'dark') {
+        root.classList.add('dark')
+      } else {
+        root.classList.remove('dark')
+      }
     }
 
     const handleChange = () => {

--- a/clients/tailwind.config.js
+++ b/clients/tailwind.config.js
@@ -6,7 +6,7 @@ import prefixer from '@tailwindcss/prefixer';
 export default {
         // Avoid conflict with WP admin styles
         content: ['./**/*.php', './index.html', './src/**/*.{js,jsx,ts,tsx}'],
-	darkMode: true,
+        darkMode: 'class',
 	important: '#wpam-auctions-root',
 	// theme: {
 	// 	extend: {


### PR DESCRIPTION
## Summary
- use Tailwind `darkMode: 'class'`
- toggle the `dark` class on `<html>` via React theme provider

## Testing
- `npm run lint` *(fails: react-refresh/only-export-components in multiple files, '__dirname' is not defined in vite.config.js)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897478121308333aaf7c6913ed8d473