### PR TITLE
Ensure lead user hidden for sealed auctions

### DIFF
--- a/includes/class-wpam-bid.php
+++ b/includes/class-wpam-bid.php
@@ -707,16 +707,17 @@ class WPAM_Bid {
 		$reverse = self::is_reverse( $auction_id );
 		$sealed  = self::is_sealed( $auction_id );
 
-		$query   = $reverse ? "SELECT MIN(bid_amount) FROM $table WHERE auction_id = %d" : "SELECT MAX(bid_amount) FROM $table WHERE auction_id = %d";
-		$highest = $wpdb->get_var( $wpdb->prepare( $query, $auction_id ) );
-		$highest = $highest ? ( function_exists( 'wc_format_decimal' ) ? (float) wc_format_decimal( $highest ) : (float) $highest ) : 0;
+                $query   = $reverse ? "SELECT MIN(bid_amount) FROM $table WHERE auction_id = %d" : "SELECT MAX(bid_amount) FROM $table WHERE auction_id = %d";
+                $highest = $wpdb->get_var( $wpdb->prepare( $query, $auction_id ) );
+                $highest = $highest ? ( function_exists( 'wc_format_decimal' ) ? (float) wc_format_decimal( $highest ) : (float) $highest ) : 0;
+                $lead_user = (int) get_post_meta( $auction_id, '_auction_lead_user', true );
 
-		if ( $sealed || self::silent_enabled( $auction_id ) ) {
-			$end    = get_post_meta( $auction_id, '_auction_end', true );
-			$end_ts = $end ? ( new \DateTimeImmutable( $end, new \DateTimeZone( 'UTC' ) ) )->getTimestamp() : 0;
-			if ( current_datetime()->getTimestamp() < $end_ts ) {
-				$highest   = 0;
-				$lead_user = 0;
+                if ( $sealed || self::silent_enabled( $auction_id ) ) {
+                        $end    = get_post_meta( $auction_id, '_auction_end', true );
+                        $end_ts = $end ? ( new \DateTimeImmutable( $end, new \DateTimeZone( 'UTC' ) ) )->getTimestamp() : 0;
+                        if ( current_datetime()->getTimestamp() < $end_ts ) {
+                                $highest   = 0;
+                                $lead_user = 0;
 			}
 		}
 


### PR DESCRIPTION
## Summary
- Load `_auction_lead_user` before checking sealed/silent auction state
- Reset lead user to `0` when bids should remain hidden

## Testing
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests` *(fails: Undefined array key "HTTP_HOST" / headers already sent)*

------
https://chatgpt.com/codex/tasks/task_e_68a4813c08c48333989e1105fd426b3f