### PR TITLE
Add database wrapper and initial usage

### DIFF
--- a/admin/class-wpam-bids-table.php
+++ b/admin/class-wpam-bids-table.php
@@ -2,11 +2,13 @@
 namespace WPAM\Admin;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+        exit; // Exit if accessed directly
 }
 
+use WPAM\Includes\WPAM_DB;
+
 if ( ! class_exists( 'WP_List_Table' ) ) {
-	require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+        require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
 }
 
 class WPAM_Bids_Table extends \WP_List_Table {
@@ -18,10 +20,9 @@ class WPAM_Bids_Table extends \WP_List_Table {
 	}
 
 	public function prepare_items() {
-		global $wpdb;
-		$table = $wpdb->prefix . 'wc_auction_bids';
+               $table = WPAM_DB::table( WPAM_DB::BIDS );
 
-		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) !== $table ) {
+               if ( WPAM_DB::get_var( 'SHOW TABLES LIKE %s', array( $table ) ) !== $table ) {
 			$this->items = array();
 			$this->set_pagination_args(
 				array(
@@ -39,7 +40,7 @@ class WPAM_Bids_Table extends \WP_List_Table {
 			return;
 		}
 
-		$results     = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $table WHERE auction_id = %d ORDER BY bid_time DESC", $this->auction_id ), ARRAY_A );
+               $results     = WPAM_DB::get_results( "SELECT * FROM $table WHERE auction_id = %d ORDER BY bid_time DESC", array( $this->auction_id ), ARRAY_A );
 		$this->items = $results;
 		$this->set_pagination_args(
 			array(

--- a/includes/class-wpam-auction.php
+++ b/includes/class-wpam-auction.php
@@ -750,12 +750,14 @@ class WPAM_Auction {
 	}
 
 	public function handle_auction_end( $auction_id ) {
-		global $wpdb;
-
-			$table   = $wpdb->prefix . 'wc_auction_bids';
-			$reverse = get_post_meta( $auction_id, '_auction_type', true ) === 'reverse';
-			$order   = $reverse ? 'ASC' : 'DESC';
-			$highest = $wpdb->get_row( $wpdb->prepare( "SELECT user_id, bid_amount FROM $table WHERE auction_id = %d ORDER BY bid_amount {$order} LIMIT 1", $auction_id ), ARRAY_A );
+               $table   = WPAM_DB::table( WPAM_DB::BIDS );
+               $reverse = get_post_meta( $auction_id, '_auction_type', true ) === 'reverse';
+               $order   = $reverse ? 'ASC' : 'DESC';
+               $highest = WPAM_DB::get_row(
+                       "SELECT user_id, bid_amount FROM $table WHERE auction_id = %d ORDER BY bid_amount {$order} LIMIT 1",
+                       array( $auction_id ),
+                       ARRAY_A
+               );
 
 			$ending_reason             = '';
 			list( $start_ts, $end_ts ) = $this->get_auction_timestamps( $auction_id );

--- a/includes/class-wpam-db.php
+++ b/includes/class-wpam-db.php
@@ -1,0 +1,94 @@
+<?php
+namespace WPAM\Includes;
+
+if ( ! defined( 'ABSPATH' ) ) {
+        exit; // Exit if accessed directly
+}
+
+final class WPAM_DB {
+        public const BIDS             = 'wc_auction_bids';
+        public const WATCHLISTS       = 'wc_auction_watchlists';
+        public const MESSAGES         = 'wc_auction_messages';
+        public const AUDIT            = 'wc_auction_audit';
+        public const FLAGGED          = 'wc_flagged_users';
+        public const KYC_FAILURES     = 'wc_kyc_failures';
+        public const LOGS             = 'wc_auction_logs';
+        public const NOTIFICATION_LOGS = 'wc_notification_logs';
+
+        private static function db() {
+                global $wpdb;
+                return $wpdb;
+        }
+
+        public static function wpdb() {
+                return self::db();
+        }
+
+        public static function table( string $name ): string {
+                return self::db()->prefix . $name;
+        }
+
+        public static function prepare( string $query, array $args = array() ) {
+                return $args ? self::db()->prepare( $query, $args ) : $query;
+        }
+
+        private static function handle_error(): void {
+                $error = self::db()->last_error;
+                if ( ! empty( $error ) ) {
+                        throw new \RuntimeException( $error );
+                }
+        }
+
+        public static function get_results( string $query, array $args = array(), string $output = OBJECT ) {
+                $sql     = self::prepare( $query, $args );
+                $results = self::db()->get_results( $sql, $output );
+                self::handle_error();
+                return $results;
+        }
+
+        public static function get_row( string $query, array $args = array(), string $output = OBJECT, int $y = 0 ) {
+                $sql = self::prepare( $query, $args );
+                $row = self::db()->get_row( $sql, $output, $y );
+                self::handle_error();
+                return $row;
+        }
+
+        public static function get_var( string $query, array $args = array(), int $x = 0, int $y = 0 ) {
+                $sql = self::prepare( $query, $args );
+                $var = self::db()->get_var( $sql, $x, $y );
+                self::handle_error();
+                return $var;
+        }
+
+        public static function get_col( string $query, array $args = array(), int $x = 0 ) {
+                $sql = self::prepare( $query, $args );
+                $col = self::db()->get_col( $sql, $x );
+                self::handle_error();
+                return $col;
+        }
+
+        public static function query( string $query, array $args = array() ) {
+                $sql    = self::prepare( $query, $args );
+                $result = self::db()->query( $sql );
+                self::handle_error();
+                return $result;
+        }
+
+        public static function insert( string $table, array $data, $format = null ) {
+                $result = self::db()->insert( $table, $data, $format );
+                self::handle_error();
+                return $result;
+        }
+
+        public static function update( string $table, array $data, array $where, $format = null, $where_format = null ) {
+                $result = self::db()->update( $table, $data, $where, $format, $where_format );
+                self::handle_error();
+                return $result;
+        }
+
+        public static function delete( string $table, array $where, $where_format = null ) {
+                $result = self::db()->delete( $table, $where, $where_format );
+                self::handle_error();
+                return $result;
+        }
+}

--- a/tests/test-db.php
+++ b/tests/test-db.php
@@ -1,0 +1,30 @@
+<?php
+use WPAM\Includes\WPAM_DB;
+
+class Test_WPAM_DB extends WP_UnitTestCase {
+        public function test_basic_crud() {
+                $table = WPAM_DB::table( WPAM_DB::BIDS );
+                WPAM_DB::insert( $table, array(
+                        'auction_id' => 1,
+                        'user_id'    => 1,
+                        'bid_amount' => 5.5,
+                        'bid_time'   => current_time( 'mysql', 1 ),
+                ), array( '%d', '%d', '%f', '%s' ) );
+
+                $count = WPAM_DB::get_var( "SELECT COUNT(*) FROM $table WHERE auction_id = %d", array( 1 ) );
+                $this->assertEquals( 1, intval( $count ) );
+
+                WPAM_DB::update( $table, array( 'bid_amount' => 6 ), array( 'auction_id' => 1, 'user_id' => 1 ), array( '%f' ), array( '%d', '%d' ) );
+                $amount = WPAM_DB::get_var( "SELECT bid_amount FROM $table WHERE auction_id = %d AND user_id = %d", array( 1, 1 ) );
+                $this->assertEquals( 6, floatval( $amount ) );
+
+                WPAM_DB::delete( $table, array( 'auction_id' => 1 ), array( '%d' ) );
+                $count = WPAM_DB::get_var( "SELECT COUNT(*) FROM $table WHERE auction_id = %d", array( 1 ) );
+                $this->assertEquals( 0, intval( $count ) );
+        }
+
+        public function test_error_handling() {
+                $this->expectException( RuntimeException::class );
+                WPAM_DB::get_var( 'SELECT * FROM non_existing_table' );
+        }
+}


### PR DESCRIPTION
## Summary
- add `WPAM_DB` static wrapper providing prepared queries and table constants
- switch bids table and select auction logic to use `WPAM_DB`
- cover wrapper with unit tests

## Testing
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/test-db.php` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a4954da2e88333b842d3d17f24161d